### PR TITLE
Stop the tool bar dimming the composer's tool-mode text on 1.21.1

### DIFF
--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ToolSelectionScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ToolSelectionScreen.java
@@ -287,6 +287,13 @@ public class ToolSelectionScreen extends Screen {
 		//? if >=1.21.6 {
 		//?} else {
 		/*
+		// The per-tool loop above ends with setShaderColor(1, 1, 1, alpha), where alpha is 0.2
+		// while the bar is unfocused, and the loop's last tool is never the selected one. That
+		// is global GL state rather than part of the pose stack, so popPose does not restore
+		// it and the composer's tool-mode text, drawn next, inherits the alpha. Only 1.21.1
+		// reaches here dirty: 1.21.4 resets unconditionally further up and then stops using
+		// shader colour, and 1.21.6+ dropped the API from this path entirely.
+		RenderSystem.setShaderColor(1, 1, 1, 1);
 		ms.pose().popPose();
 		*///?}
 	}


### PR DESCRIPTION
On 1.21.1 the composer's tool-mode text renders at one-fifth opacity. `ToolSelectionScreen`'s per-tool loop ends with

```java
RenderSystem.setShaderColor(1, 1, 1, alpha);   // alpha == 0.2 when the bar is unfocused
```

`alpha` is `focused ? 1 : .2f`, raised to `1` only for the selected tool. There are 11 tools, `Room` (index 0) is selected by default, and the loop's last iteration is `Palette` (index 10) — so the final write is almost always the dim one.

That call is **global GL state, not part of the pose stack**, so the `popPose()` that follows does not restore it. The method returns with the shader colour still at `(1, 1, 1, 0.2)`.

`PhaseComposing.renderGameOverlay` draws the active tool's overlay immediately afterwards:

```
toolSelection.renderPassive(ms, pt)      ← leaks (1,1,1,0.2)
activeTool.getTool().renderOverlay(ms)   ← drawn at 20% opacity
menu.drawPassive(...)                    ← sets its own colour, then resets to (1,1,1,1)
HudTextBuffer.render(...)                ← unaffected
```

The damage window is bounded. `ArchitectMenuScreen.draw` sets its own shader colour and resets it, incidentally repairing the state, so the menu and the world-space measurement labels drawn later are fine. In game that presents as **dim tool-mode text with correct dimension labels** — confirmed by an A/B of a patched and an unpatched 1.21.1 client.

## Fix

One line, restoring the identity colour before the method returns.

## Scope

| version | live `setShaderColor` calls | before | after |
|---|---:|---|---|
| **1.21.1** | 7 | exits at `(1,1,1,0.2)` | exits at `(1,1,1,1)` |
| 1.21.4 | 5 | already clean — unconditional reset further up, then packed colour ints for icons | unchanged |
| 1.21.6 – 26.1 | 0 | API dropped from this path | unchanged |

`ToolSelectionScreen` lives in `common` with no loader override, and `RenderSystem.setShaderColor` is vanilla Blaze3D, so **Fabric and NeoForge are affected identically**.

**Not a migration regression.** The shipped 0.9.0+45 jar (`archive/1.21.1`) contains the same sequence, so this has been live in the published mod.

The fix originated on a local, never-pushed branch (`fix/26-27-1.21.1`), found while auditing branches before retiring them. The other four changes on that branch — the `getX()`/`getY()` migration that fixes the NeoForge `IllegalAccessError` in #27 — already reached `main` independently via the migration; this was the one that hadn't.

## Validation

- Generated all 7 versions and checked the last live `setShaderColor` call in each (comment-stripped, so commented-out Stonecutter arms don't produce false positives): every version now ends at `(1, 1, 1, 1)`, and 1.21.6+ still have none at all.
- `buildAll` 14/14.
- A/B of two 1.21.1 Fabric clients, stock vs patched, jars hash-verified in-instance.
