### PR TITLE
Add 1.19.4, 1.20.1, 1.20.2, 1.20.4 and 1.20.6 to the version matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,34 +13,59 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # One job per Minecraft version; each builds BOTH loaders (they share the
-        # :common:<mc> compile under Stonecutter, so pairing them avoids a double compile).
-        mc: ["1.21.1", "1.21.4", "1.21.6", "1.21.8", "1.21.10", "1.21.11", "26.1", "26.2"]
+        # One job per Minecraft version; each builds every loader that version targets (they share
+        # the :common:<mc> compile under Stonecutter, so pairing them avoids a double compile).
+        #
+        # `loader2` is the Forge-family loader for that version:
+        #   forge     - 1.19.4 and 1.20.1, which predate NeoForge (and NeoForge 1.20.1 loads Forge mods)
+        #   neoforge  - 1.20.4 and newer
+        #   ""        - 1.20.2, which is Fabric-only: ModDevGradle resolves NeoForge through Gradle
+        #               module metadata and no 20.2 or 20.3 build ever published any.
+        include:
+          - { mc: "1.19.4",  loader2: forge }
+          - { mc: "1.20.1",  loader2: forge }
+          - { mc: "1.20.2",  loader2: "" }
+          - { mc: "1.20.4",  loader2: neoforge }
+          - { mc: "1.20.6",  loader2: neoforge }
+          - { mc: "1.21.1",  loader2: neoforge }
+          - { mc: "1.21.4",  loader2: neoforge }
+          - { mc: "1.21.6",  loader2: neoforge }
+          - { mc: "1.21.8",  loader2: neoforge }
+          - { mc: "1.21.10", loader2: neoforge }
+          - { mc: "1.21.11", loader2: neoforge }
+          - { mc: "26.1",    loader2: neoforge }
+          - { mc: "26.2",    loader2: neoforge }
     steps:
       - uses: actions/checkout@v4
         with:
           # Root build.gradle derives the CI version from `git rev-list --count HEAD`.
           fetch-depth: 0
 
-      # Install both toolchains: obf nodes (<=1.21.x) use JDK 21, the unobfuscated 26.x nodes use JDK 25.
+      # Install every toolchain the matrix needs: 1.19.4..1.20.4 target JDK 17, the remaining
+      # obf nodes (<=1.21.x) use JDK 21, and the unobfuscated 26.x nodes use JDK 25.
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: |
+            17
             21
             25
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Build ${{ matrix.mc }} (both loaders)
+      - name: Build ${{ matrix.mc }}
+        env:
+          JDKS: JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64
         run: |
           chmod +x ./gradlew
-          ./gradlew ":fabric:${{ matrix.mc }}:build" ":neoforge:${{ matrix.mc }}:build" \
-            -Porg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64,JAVA_HOME_25_X64 \
-            --stacktrace
+          tasks=":fabric:${{ matrix.mc }}:build"
+          if [ -n "${{ matrix.loader2 }}" ]; then
+            tasks="$tasks :${{ matrix.loader2 }}:${{ matrix.mc }}:build"
+          fi
+          ./gradlew $tasks -Porg.gradle.java.installations.fromEnv=$JDKS --stacktrace
 
       # Guards the exact bug packaged E2E caught: metadata must declare THIS version's
-      # dependency range, not the 26.x base's hardcoded one. Expected values are read from
+      # dependency range, not the newest node's hardcoded one. Expected values are read from
       # the version's own gradle.properties so the assertion cannot drift from the build.
       - name: Verify mod metadata version range
         run: |
@@ -53,24 +78,33 @@ jobs:
           [ -n "$mc_min" ] && [ -n "$mc_max" ] && [ -n "$pack_format" ] \
             || { echo "::error::$props is missing meta_mc_range, meta_mc_max or meta_pack_format"; exit 1; }
 
-          nf_jar=$(ls neoforge/versions/${{ matrix.mc }}/build/libs/*neoforge.jar | grep -Ev 'sources|dev|raw' | head -n1)
-          unzip -p "$nf_jar" META-INF/neoforge.mods.toml > /tmp/nf.toml
-          echo "--- neoforge.mods.toml ---"; cat /tmp/nf.toml
-          grep -A2 'modId = "minecraft"' /tmp/nf.toml | grep -qF "versionRange = \"[$mc_min,$mc_max)\"" \
-            || { echo "::error::neoforge minecraft versionRange is not [$mc_min,$mc_max)"; exit 1; }
+          if [ -n "${{ matrix.loader2 }}" ]; then
+            l2_jar=$(ls ${{ matrix.loader2 }}/versions/${{ matrix.mc }}/build/libs/*${{ matrix.loader2 }}.jar \
+              | grep -Ev 'sources|dev|raw|client-test|server-test' | head -n1)
+            # Forge reads META-INF/mods.toml; NeoForge reads META-INF/neoforge.mods.toml.
+            toml=$(unzip -Z1 "$l2_jar" | grep -E '^META-INF/(neoforge\.)?mods\.toml$' | head -n1)
+            [ -n "$toml" ] || { echo "::error::$l2_jar has no META-INF mods toml"; exit 1; }
+            unzip -p "$l2_jar" "$toml" > /tmp/l2.toml
+            echo "--- $toml ---"; cat /tmp/l2.toml
+            grep -A3 'modId = "minecraft"' /tmp/l2.toml | grep -qF "versionRange = \"[$mc_min,$mc_max)\"" \
+              || { echo "::error::${{ matrix.loader2 }} minecraft versionRange is not [$mc_min,$mc_max)"; exit 1; }
 
-          unzip -p "$nf_jar" pack.mcmeta > /tmp/nf.mcmeta
-          echo "--- pack.mcmeta ---"; cat /tmp/nf.mcmeta
-          grep -qE "\"pack_format\"[[:space:]]*:[[:space:]]*$pack_format[[:space:]]*$" /tmp/nf.mcmeta \
-            || { echo "::error::neoforge pack_format is not $pack_format"; exit 1; }
+            unzip -p "$l2_jar" pack.mcmeta > /tmp/l2.mcmeta
+            echo "--- pack.mcmeta ---"; cat /tmp/l2.mcmeta
+            grep -qE "\"pack_format\"[[:space:]]*:[[:space:]]*$pack_format[[:space:]]*$" /tmp/l2.mcmeta \
+              || { echo "::error::${{ matrix.loader2 }} pack_format is not $pack_format"; exit 1; }
+          else
+            echo "Fabric-only version; no second loader to verify."
+          fi
 
-          fb_jar=$(ls fabric/versions/${{ matrix.mc }}/build/libs/*fabric.jar | grep -Ev 'sources|dev|raw' | head -n1)
+          fb_jar=$(ls fabric/versions/${{ matrix.mc }}/build/libs/*fabric.jar \
+            | grep -Ev 'sources|dev|raw|client-test|server-test' | head -n1)
           unzip -p "$fb_jar" fabric.mod.json > /tmp/fb.json
           echo "--- fabric.mod.json ---"; cat /tmp/fb.json
           grep -qF "\"minecraft\": \">=$mc_min <$mc_max\"" /tmp/fb.json \
             || { echo "::error::fabric minecraft depend is not >=$mc_min <$mc_max"; exit 1; }
 
-      - name: Dedicated server smoke (both loaders)
+      - name: Dedicated server smoke
         shell: pwsh
         run: ./scripts/run-server-test-matrix.ps1 -Versions '${{ matrix.mc }}'
 
@@ -79,7 +113,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y xvfb libgl1 libgl1-mesa-dri mesa-utils
 
-      - name: Automated client feature tests (both loaders)
+      - name: Automated client feature tests
         env:
           CI: true
           LIBGL_ALWAYS_SOFTWARE: "1"
@@ -104,10 +138,11 @@ jobs:
           if-no-files-found: error
           path: |
             fabric/versions/${{ matrix.mc }}/build/libs/*fabric.jar
+            forge/versions/${{ matrix.mc }}/build/libs/*forge.jar
             neoforge/versions/${{ matrix.mc }}/build/libs/*neoforge.jar
 
   # Single aggregated status to use as the required check in branch protection:
-  # a PR only passes when all 8 versions x 2 loaders build green + metadata verifies.
+  # a PR only passes when every version builds green and its metadata verifies.
   all-green:
     name: All versions green
     needs: build
@@ -120,4 +155,4 @@ jobs:
             echo "One or more version builds failed."
             exit 1
           fi
-          echo "All 8 versions x 2 loaders built green."
+          echo "All 13 versions built green (25 jars: 13 Fabric + 12 Forge-family)."

--- a/README.md
+++ b/README.md
@@ -13,10 +13,18 @@ This is experimental. Some things may still be broken!
 
 ## Contributing
 
-Everything lives on `main`. One source tree builds 8 Minecraft versions x 2 loaders
-(16 targets) through [Stonecutter](https://stonecutter.kikugie.dev/); there are no
-per-version branches. The versions are listed in `settings.gradle`, and each has its
-own dependency and metadata values in `versions/<mc>/gradle.properties`.
+Everything lives on `main`. One source tree builds 13 Minecraft versions - 25 jars - through
+[Stonecutter](https://stonecutter.kikugie.dev/); there are no per-version branches. The versions are
+listed in `settings.gradle`, and each has its own dependency and metadata values in
+`versions/<mc>/gradle.properties`.
+
+Every version ships a Fabric jar. The second loader depends on the era:
+
+| versions | second loader | why |
+| --- | --- | --- |
+| 1.19.4, 1.20.1 | Forge | NeoForge did not exist yet; NeoForge 1.20.1 loads Forge mods anyway |
+| 1.20.2 | *none* | ModDevGradle resolves NeoForge through Gradle module metadata, and no 20.2 or 20.3 build ever published any, so NeoForge cannot be built for it at all |
+| 1.20.4 and newer | NeoForge | |
 
 ### Layout
 
@@ -25,6 +33,7 @@ own dependency and metadata values in `versions/<mc>/gradle.properties`.
 | `common/` | the shared source. No toolchain of its own - Stonecutter processes it per Minecraft version and both loader modules compile the result directly (source inclusion). |
 | `fabric/` | Fabric entrypoints and metadata, built with [Fabric Loom](https://github.com/FabricMC/fabric-loom). |
 | `neoforge/` | NeoForge entrypoints and metadata, built with [ModDevGradle](https://github.com/neoforged/ModDevGradle). |
+| `forge/` | Forge entrypoints and metadata for 1.19.4 and 1.20.1, built with [ModDevGradle's legacy plugin](https://github.com/neoforged/ModDevGradle/blob/main/LEGACY.md). |
 | `client-test/` | the automated in-game client test companion mod. |
 | `server-test/` | the automated dedicated-server test companion mod (print-to-world). |
 
@@ -56,15 +65,23 @@ public void drawPassive(GuiGraphics graphics, float partialTicks) {
 ```
 
 Stonecutter rewrites these in place when you switch the active version, commenting
-out the arms that do not apply. Two consequences worth knowing: a block comment
-cannot nest, so each arm must close before the next opens; and an arm containing
-only comments loses its marker and becomes live code, so never guard commentary.
+out the arms that do not apply. Three consequences worth knowing: a block comment
+cannot nest, so each arm must close before the next opens; an arm containing only
+comments loses its marker and becomes live code, so never guard commentary; and a
+`//` comment placed between an arm's marker and its `/*` body loses its marker the
+same way, so keep such comments inside the body.
 
 ```powershell
 ./gradlew stonecutterSwitchTo1.21.8   # switch which version the tree targets
-./gradlew buildAll                     # build all 16 targets
+./gradlew compileAll                   # compile every node and source set - the local inner loop
+./gradlew buildAll                     # build all 25 jars
 ./gradlew ":fabric:1.21.8:build"       # build one target
+./gradlew ":forge:1.20.1:build"        # the Forge branch only covers 1.19.4 and 1.20.1
 ```
+
+Prefer `compileAll` locally and let CI run the matrices: it validates every version in
+parallel on clean runners, where a full local matrix takes hours and collides with other
+worktrees on ports and Gradle daemons.
 
 Switching rewrites the tree in place, so it leaves a cosmetic diff on files with
 empty guard arms. That churn carries no behaviour and is safe to discard with
@@ -78,10 +95,11 @@ Branches from before the migration are kept as tags rather than branches. `git t
 
 ## Runtime testing
 
-PowerShell 7 is required.
+PowerShell 7 is required. The matrices cover every version and each version's loaders;
+`-Loaders` narrows them, and a version with no NeoForge build runs Forge, or Fabric alone.
 
 ```powershell
-# All versions x both loaders
+# All versions x their loaders
 pwsh -File scripts/run-server-test-matrix.ps1
 pwsh -File scripts/run-client-test-matrix.ps1
 

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -21,4 +21,7 @@ file("../gradle.properties").withInputStream { rootProps.load(it) }
 dependencies {
     implementation "net.fabricmc:fabric-loom:${rootProps.loom_version}"
     implementation "net.neoforged.moddev:net.neoforged.moddev.gradle.plugin:${rootProps.moddev_version}"
+    // ModDevGradle's legacy addon, released in lockstep with the main plugin. It is what builds
+    // the 1.19.4 / 1.20.1 Forge targets, where NeoForge does not exist yet.
+    implementation "net.neoforged.moddev.legacyforge:net.neoforged.moddev.legacyforge.gradle.plugin:${rootProps.moddev_version}"
 }

--- a/buildSrc/src/main/groovy/mightyarchitect.moddev-legacy.gradle
+++ b/buildSrc/src/main/groovy/mightyarchitect.moddev-legacy.gradle
@@ -1,0 +1,5 @@
+// Forge toolchain for the pre-NeoForge nodes (1.19.4, 1.20.1): ModDevGradle's legacy addon, which
+// layers SRG reobfuscation and Forge's runtime onto the same plugin the NeoForge nodes use.
+plugins {
+    id "net.neoforged.moddev.legacyforge"
+}

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -256,10 +256,56 @@ public final class ClientTestController {
 
         String server = System.getProperty("mightyarchitect.clientTest.server", "127.0.0.1:25565");
         ServerAddress address = ServerAddress.parseString(server);
-        ServerData data = new ServerData("Mighty Architect Client Test", server, ServerData.Type.OTHER);
+        ServerData data = createServerData(server);
         TheMightyArchitect.logger.info("[CLIENT-TEST] Connecting to {}", server);
-        ConnectScreen.startConnecting(McCompat.currentScreen(minecraft), minecraft, address, data, false, null);
+        startConnecting(minecraft, address, data);
         advance(Stage.WAIT_FOR_WORLD);
+    }
+
+    // This source set is shared verbatim by every Stonecutter node (it is not preprocessed), so
+    // the two multiplayer entry points whose signatures moved between 1.19.4 and 1.21 are bound
+    // reflectively instead of guarded: ServerData's third argument became a Type in 1.20.2, and
+    // ConnectScreen.startConnecting gained a quick-play flag in 1.20.1 and a transfer state in 1.20.5.
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private static ServerData createServerData(String server) {
+        for (java.lang.reflect.Constructor<?> constructor : ServerData.class.getConstructors()) {
+            Class<?>[] parameters = constructor.getParameterTypes();
+            if (parameters.length != 3 || parameters[0] != String.class || parameters[1] != String.class)
+                continue;
+            Object third = parameters[2] == boolean.class
+                ? Boolean.FALSE
+                : Enum.valueOf((Class<Enum>) parameters[2], "OTHER");
+            try {
+                return (ServerData) constructor.newInstance("Mighty Architect Client Test", server, third);
+            } catch (ReflectiveOperationException exception) {
+                throw new IllegalStateException("Unable to build the client-test ServerData", exception);
+            }
+        }
+        throw new IllegalStateException("No usable ServerData constructor found");
+    }
+
+    private static void startConnecting(Minecraft minecraft, ServerAddress address, ServerData data) {
+        for (java.lang.reflect.Method method : ConnectScreen.class.getDeclaredMethods()) {
+            if (!method.getName().equals("startConnecting") || !java.lang.reflect.Modifier.isStatic(method.getModifiers()))
+                continue;
+            Class<?>[] parameters = method.getParameterTypes();
+            if (parameters.length < 4 || parameters[3] != ServerData.class)
+                continue;
+            Object[] arguments = new Object[parameters.length];
+            arguments[0] = McCompat.currentScreen(minecraft);
+            arguments[1] = minecraft;
+            arguments[2] = address;
+            arguments[3] = data;
+            for (int i = 4; i < parameters.length; i++)
+                arguments[i] = parameters[i] == boolean.class ? Boolean.FALSE : null;
+            try {
+                method.invoke(null, arguments);
+                return;
+            } catch (ReflectiveOperationException exception) {
+                throw new IllegalStateException("Unable to start the client-test connection", exception);
+            }
+        }
+        throw new IllegalStateException("No usable ConnectScreen.startConnecting overload found");
     }
 
     private static void waitForWorld(Minecraft minecraft) {

--- a/client-test/src/main/resources/mightyarchitect-test.mixins.json
+++ b/client-test/src/main/resources/mightyarchitect-test.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.timmie.mightyarchitect.test.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_${meta_java_range}",
   "client": [
     "ArchitectManagerProbeMixin",
     "ArchitectManagerAccessor",

--- a/common/src/main/java/com/timmie/mightyarchitect/AllPackets.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/AllPackets.java
@@ -3,36 +3,30 @@ package com.timmie.mightyarchitect;
 import com.timmie.mightyarchitect.networking.InstantPrintPacket;
 import com.timmie.mightyarchitect.networking.PlaceSignPacket;
 import com.timmie.mightyarchitect.networking.SetHotbarItemPacket;
+import com.timmie.mightyarchitect.platform.MightyPacket;
 import com.timmie.mightyarchitect.platform.PacketSender;
+//? if >=1.20.5 {
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-//? if >=1.21.11 {
-import net.minecraft.resources.Identifier;
 //?} else {
-/*import net.minecraft.resources.ResourceLocation;
+/*import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import java.util.function.Function;
 *///?}
 
 // Payload identities and codecs. Registration and delivery are the loader's job: this class only
 // describes what the packets are, so the same description drives Fabric's PayloadTypeRegistry and
-// NeoForge's PayloadRegistrar.
+// NeoForge's PayloadRegistrar - or, before 1.20.5, the loader's raw channel registration.
 public class AllPackets {
 
-	//? if >=1.21.11 {
+	//? if >=1.20.5 {
 	public static final CustomPacketPayload.Type<InstantPrintPacket> INSTANT_PRINT_TYPE =
-		new CustomPacketPayload.Type<>(Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, "instant_print"));
+		new CustomPacketPayload.Type<>(TheMightyArchitect.id("instant_print"));
 	public static final CustomPacketPayload.Type<PlaceSignPacket> PLACE_SIGN_TYPE =
-		new CustomPacketPayload.Type<>(Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, "place_sign"));
+		new CustomPacketPayload.Type<>(TheMightyArchitect.id("place_sign"));
 	public static final CustomPacketPayload.Type<SetHotbarItemPacket> SET_HOTBAR_ITEM_TYPE =
-		new CustomPacketPayload.Type<>(Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, "set_hotbar_item"));
-	//?} else {
-	/*public static final CustomPacketPayload.Type<InstantPrintPacket> INSTANT_PRINT_TYPE =
-		new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "instant_print"));
-	public static final CustomPacketPayload.Type<PlaceSignPacket> PLACE_SIGN_TYPE =
-		new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "place_sign"));
-	public static final CustomPacketPayload.Type<SetHotbarItemPacket> SET_HOTBAR_ITEM_TYPE =
-		new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "set_hotbar_item"));
-	*///?}
+		new CustomPacketPayload.Type<>(TheMightyArchitect.id("set_hotbar_item"));
 
 	public static final StreamCodec<RegistryFriendlyByteBuf, InstantPrintPacket> INSTANT_PRINT_CODEC =
 		StreamCodec.of(InstantPrintPacket::write, InstantPrintPacket::new);
@@ -40,6 +34,17 @@ public class AllPackets {
 		StreamCodec.of(PlaceSignPacket::write, PlaceSignPacket::new);
 	public static final StreamCodec<RegistryFriendlyByteBuf, SetHotbarItemPacket> SET_HOTBAR_ITEM_CODEC =
 		StreamCodec.of(SetHotbarItemPacket::write, SetHotbarItemPacket::new);
+	//?} else {
+	/*// Before 1.20.5 there are no payload types and no stream codecs: a packet is a channel id
+	// plus a decoder, and the loader pairs the two up itself.
+	public static final ResourceLocation INSTANT_PRINT_ID = TheMightyArchitect.id("instant_print");
+	public static final ResourceLocation PLACE_SIGN_ID = TheMightyArchitect.id("place_sign");
+	public static final ResourceLocation SET_HOTBAR_ITEM_ID = TheMightyArchitect.id("set_hotbar_item");
+
+	public static final Function<FriendlyByteBuf, InstantPrintPacket> INSTANT_PRINT_DECODER = InstantPrintPacket::new;
+	public static final Function<FriendlyByteBuf, PlaceSignPacket> PLACE_SIGN_DECODER = PlaceSignPacket::new;
+	public static final Function<FriendlyByteBuf, SetHotbarItemPacket> SET_HOTBAR_ITEM_DECODER = SetHotbarItemPacket::new;
+	*///?}
 
 	private static PacketSender sender = packet -> {
 	};
@@ -48,7 +53,7 @@ public class AllPackets {
 		sender = value;
 	}
 
-	public static void sendToServer(CustomPacketPayload packet) {
+	public static void sendToServer(MightyPacket packet) {
 		sender.sendToServer(packet);
 	}
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/AllSpecialTextures.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/AllSpecialTextures.java
@@ -43,8 +43,10 @@ public enum AllSpecialTextures {
     private AllSpecialTextures(String filename) {
         //? if >=1.21.11 {
         location = Identifier.fromNamespaceAndPath(TheMightyArchitect.ID,
-        //?} else {
+        //?} else if >=1.21 {
         /*location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID,
+        *///?} else {
+        /*location = new ResourceLocation(TheMightyArchitect.ID,
         *///?}
                 "textures/block/marker/" + filename);
     }

--- a/common/src/main/java/com/timmie/mightyarchitect/TheMightyArchitect.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/TheMightyArchitect.java
@@ -19,14 +19,21 @@ public class TheMightyArchitect {
 	public static TheMightyArchitect instance;
 	public static Logger logger = LogManager.getLogger();
 
+	// ResourceLocation's public constructor was replaced by the fromNamespaceAndPath factory in
+	// 1.21, and the class itself was renamed to Identifier in 1.21.11.
 	//? if >=1.21.11 {
 	public static Identifier id(String path) {
 		return Identifier.fromNamespaceAndPath(ID, path);
 	}
 
-	//?} else {
+	//?} else if >=1.21 {
 	/*public static ResourceLocation id(String path) {
 		return ResourceLocation.fromNamespaceAndPath(ID, path);
+	}
+
+	*///?} else {
+	/*public static ResourceLocation id(String path) {
+		return new ResourceLocation(ID, path);
 	}
 
 	*///?}

--- a/common/src/main/java/com/timmie/mightyarchitect/block/DesignAnchorBlock.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/block/DesignAnchorBlock.java
@@ -6,8 +6,10 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition.Builder;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 //? if >=1.21.4 {
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.world.level.material.MapColor;
+*///?} else {
+/*import net.minecraft.world.level.material.Material;
 *///?}
 
 public class DesignAnchorBlock extends Block {
@@ -17,9 +19,12 @@ public class DesignAnchorBlock extends Block {
 	//? if >=1.21.4 {
 	public DesignAnchorBlock(Properties properties) {
 		super(properties);
-	//?} else {
+	//?} else if >=1.20 {
 	/*public DesignAnchorBlock() {
 		super(Properties.of().mapColor(MapColor.STONE));
+	*///?} else {
+	/*public DesignAnchorBlock() {
+		super(Properties.of(Material.STONE));
 	*///?}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/block/SliceMarkerBlock.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/block/SliceMarkerBlock.java
@@ -15,8 +15,10 @@ import net.minecraft.world.level.block.state.StateDefinition.Builder;
 import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 //? if >=1.21.4 {
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.world.level.material.MapColor;
+*///?} else {
+/*import net.minecraft.world.level.material.Material;
 *///?}
 import net.minecraft.world.phys.BlockHitResult;
 
@@ -29,9 +31,12 @@ public class SliceMarkerBlock extends Block {
 	//? if >=1.21.4 {
 	public SliceMarkerBlock(Properties properties) {
 		super(properties);
-	//?} else {
+	//?} else if >=1.20 {
 	/*public SliceMarkerBlock() {
 		super(Properties.of().mapColor(MapColor.STONE));
+	*///?} else {
+	/*public SliceMarkerBlock() {
+		super(Properties.of(Material.STONE));
 	*///?}
 		this.registerDefaultState(defaultBlockState().setValue(VARIANT, DesignSliceTrait.Standard));
 	}
@@ -50,8 +55,14 @@ public class SliceMarkerBlock extends Block {
 	}
 
 	@Override
+	// 1.20.5 split the old use(...) hook into useItemOn/useWithoutItem and dropped the hand argument.
+	//? if >=1.20.5 {
 	protected InteractionResult useWithoutItem(BlockState state, Level worldIn, BlockPos pos, Player player,
 			BlockHitResult hit) {
+	//?} else {
+	/*public InteractionResult use(BlockState state, Level worldIn, BlockPos pos, Player player,
+			net.minecraft.world.InteractionHand handIn, BlockHitResult hit) {
+	*///?}
 		if (hit.getDirection().getAxis() == Axis.Y)
 			return InteractionResult.PASS;
 		if (AllItems.ARCHITECT_WAND.typeOf(player.getMainHandItem()) || AllItems.ARCHITECT_WAND.typeOf(player.getOffhandItem()))

--- a/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectKits.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectKits.java
@@ -7,7 +7,12 @@ import com.timmie.mightyarchitect.control.design.DesignExporter;
 import com.timmie.mightyarchitect.control.palette.Palette;
 import com.timmie.mightyarchitect.networking.SetHotbarItemPacket;
 import net.minecraft.ChatFormatting;
+// Item display names moved from NBT hover-name to a data component in 1.20.5.
+//? if >=1.20.5 {
 import net.minecraft.core.component.DataComponents;
+//?} else {
+/*
+*///?}
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
@@ -83,9 +88,15 @@ public class ArchitectKits {
 	private static void setHotbarBlock(int slot, Palette palette) {
 		BlockState state = DesignExporter.theme.getDefaultPalette().get(palette);
 		ItemStack stack = new ItemStack(state.getBlock().asItem());
+		//? if >=1.20.5 {
 		stack.set(DataComponents.CUSTOM_NAME, Component.literal(ChatFormatting.RESET + "" + ChatFormatting.GOLD
 				+ palette.getDisplayName() + ChatFormatting.WHITE + " (" + ChatFormatting.GRAY
 				+ stack.getHoverName().getString() + ChatFormatting.WHITE + ")"));
+		//?} else {
+		/*stack.setHoverName(Component.literal(ChatFormatting.RESET + "" + ChatFormatting.GOLD
+				+ palette.getDisplayName() + ChatFormatting.WHITE + " (" + ChatFormatting.GRAY
+				+ stack.getHoverName().getString() + ChatFormatting.WHITE + ")"));
+		*///?}
 		setHotbarItem(slot, stack);
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
@@ -19,12 +19,17 @@ import com.timmie.mightyarchitect.foundation.utility.Keyboard;
 import com.timmie.mightyarchitect.gui.*;
 import com.timmie.mightyarchitect.networking.InstantPrintPacket;
 import net.minecraft.ChatFormatting;
+//? if >=1.21 {
 import net.minecraft.client.DeltaTracker;
+//?} else {
+/*
+*///?}
 import net.minecraft.client.Minecraft;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
-/*import net.minecraft.client.gui.GuiGraphics;*///?}
+//?} else if >=1.20 {
+/*import net.minecraft.client.gui.GuiGraphics;*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;*///?}
 import com.timmie.mightyarchitect.foundation.MightyBuffers;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -325,16 +330,22 @@ public class ArchitectManager {
 			((IDrawBlockHighlights) phaseHandler).tickHighlightOutlines();
 	}
 
+	// The HUD callback carried a raw partial-tick float until 1.21 replaced it with DeltaTracker.
 	//? if >=26 {
 	public static void onDrawGameOverlay(GuiGraphicsExtractor poseStack, DeltaTracker deltaTracker) {
-	//?} else {
-	/*public static void onDrawGameOverlay(GuiGraphics poseStack, DeltaTracker deltaTracker) {*///?}
+		float partialTicks = deltaTracker.getGameTimeDeltaPartialTick(true);
+	//?} else if >=1.21 {
+	/*public static void onDrawGameOverlay(GuiGraphics poseStack, DeltaTracker deltaTracker) {
+		float partialTicks = deltaTracker.getGameTimeDeltaPartialTick(true);
+	*///?} else {
+	/*public static void onDrawGameOverlay(GuiGraphics poseStack, float partialTicks) {
+	*///?}
 		IArchitectPhase phaseHandler = phase.getPhaseHandler();
 		if (phaseHandler instanceof IRenderGameOverlay) {
-			((IRenderGameOverlay) phaseHandler).renderGameOverlay(poseStack, deltaTracker.getGameTimeDeltaPartialTick(true));
+			((IRenderGameOverlay) phaseHandler).renderGameOverlay(poseStack, partialTicks);
 		}
 
-		menu.drawPassive(poseStack, deltaTracker.getGameTimeDeltaPartialTick(true));
+		menu.drawPassive(poseStack, partialTicks);
 		//? if <1.21.6 {
 		/*com.mojang.blaze3d.systems.RenderSystem.enableBlend();*///?}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/control/SchematicRenderer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/SchematicRenderer.java
@@ -1,9 +1,17 @@
 package com.timmie.mightyarchitect.control;
 
 import com.mojang.blaze3d.vertex.BufferBuilder;
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+//?} else {
+/*
+*///?}
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.MeshData;
+//?} else {
+/*
+*///?}
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import com.timmie.mightyarchitect.MightyClient;
@@ -215,9 +223,12 @@ public class SchematicRenderer {
 		/*Map<ChunkSectionLayer, ByteBufferBuilder> byteBuffers = new HashMap<>();
 		Map<ChunkSectionLayer, BufferBuilder> buffers = new HashMap<>();
 		PoseStack ms = new PoseStack();
-		*///?} else {
+		*///?} else if >=1.21 {
 		/*Map<RenderType, ByteBufferBuilder> byteBuffers = new HashMap<>();
 		Map<RenderType, BufferBuilder> buffers = new HashMap<>();
+		PoseStack ms = new PoseStack();
+		*///?} else {
+		/*Map<RenderType, BufferBuilder> buffers = new HashMap<>();
 		PoseStack ms = new PoseStack();
 		*///?}
 
@@ -260,7 +271,7 @@ public class SchematicRenderer {
 						buffers.get(blockRenderLayer).putBlockBakedQuad(x, y, z, quad, instance);
 						usedBlockRenderLayers.add(blockRenderLayer);
 					};
-						//?} else {
+						//?} else if >=1.21 {
 						/*if (!buffers.containsKey(blockRenderLayer))
 					{
 						int bufferSize = MightyClient.iris_presence ? 262144 : 2097152;
@@ -269,6 +280,14 @@ public class SchematicRenderer {
 						buffers.put(blockRenderLayer, com.timmie.mightyarchitect.foundation.compat.McCompat.quadBuffer(byteBuffer, DefaultVertexFormat.BLOCK));
 						startedBufferBuilders.add(blockRenderLayer);
 					}
+						*///?} else {
+						/*if (!buffers.containsKey(blockRenderLayer))
+					{
+						int bufferSize = MightyClient.iris_presence ? 262144 : 2097152;
+						buffers.put(blockRenderLayer, new BufferBuilder(bufferSize));
+					}
+					if (startedBufferBuilders.add(blockRenderLayer))
+						buffers.get(blockRenderLayer).begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
 						*///?}
 
 					//? if >=26 {
@@ -316,6 +335,7 @@ public class SchematicRenderer {
 			if (!startedBufferBuilders.contains(layer))
 				continue;
 			BufferBuilder buf = buffers.get(layer);
+			//? if >=1.21 {
 			MeshData meshData = buf.build();
 			if (meshData != null) {
 				bufferCache.put(layer, new SuperByteBuffer(meshData));
@@ -325,6 +345,12 @@ public class SchematicRenderer {
 			if (byteBuffer != null) {
 				byteBuffer.close();
 			}
+			//?} else {
+			/*var renderedBuffer = buf.end();
+			if (renderedBuffer != null) {
+				bufferCache.put(layer, new SuperByteBuffer(renderedBuffer));
+			}
+			*///?}
 		}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/ComposerToolBase.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/ComposerToolBase.java
@@ -17,8 +17,10 @@ import com.timmie.mightyarchitect.foundation.utility.RaycastHelper.PredicateTrac
 import net.minecraft.client.Minecraft;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.core.BlockPos;
@@ -111,10 +113,15 @@ public abstract class ComposerToolBase implements IComposerTool {
 		ms.pose().translate(25,
 				-Mth.lerp(mc.getDeltaTracker().getGameTimeDeltaPartialTick(true), lastToolModeYOffset, toolModeYOffset),
 				0);
-		*///?} else {
+		*/		//?} else if >=1.21 {
 		/*ms.pose().translate(mainWindow.getGuiScaledWidth() / 2, mainWindow.getGuiScaledHeight() / 2 - 3, 0);
 		ms.pose().translate(25,
 				-Mth.lerp(mc.getTimer().getGameTimeDeltaPartialTick(true), lastToolModeYOffset, toolModeYOffset),
+				0);
+		*///?} else {
+		/*ms.pose().translate(mainWindow.getGuiScaledWidth() / 2, mainWindow.getGuiScaledHeight() / 2 - 3, 0);
+		ms.pose().translate(25,
+				-Mth.lerp(mc.getFrameTime(), lastToolModeYOffset, toolModeYOffset),
 				0);
 		*///?}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/CylinderRoomTool.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/CylinderRoomTool.java
@@ -34,7 +34,12 @@ public class CylinderRoomTool extends RoomTool {
 		LocalPlayer player = Minecraft.getInstance().player;
 		transparentStacks.clear();
 
+		// Entity.level() replaced the public level field in 1.20.
+		//? if >=1.20 {
 		BlockHitResult trace = RaycastHelper.rayTraceRange(player.level(), player, 75);
+		//?} else {
+		/*BlockHitResult trace = RaycastHelper.rayTraceRange(player.level, player, 75);
+		*///?}
 		if (trace != null && trace.getType() == Type.BLOCK) {
 
 			BlockPos hit = trace.getBlockPos();

--- a/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/GroundPlanningToolBase.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/GroundPlanningToolBase.java
@@ -44,7 +44,12 @@ public abstract class GroundPlanningToolBase extends ComposerToolBase {
 		LocalPlayer player = Minecraft.getInstance().player;
 		transparentStacks.clear();
 
+		// Entity.level() replaced the public level field in 1.20.
+		//? if >=1.20 {
 		BlockHitResult trace = RaycastHelper.rayTraceRange(player.level(), player, 75);
+		//?} else {
+		/*BlockHitResult trace = RaycastHelper.rayTraceRange(player.level, player, 75);
+		*///?}
 		if (trace != null && trace.getType() == Type.BLOCK) {
 
 			var hitVec = trace.getLocation();
@@ -52,7 +57,11 @@ public abstract class GroundPlanningToolBase extends ComposerToolBase {
 			BlockPos hit = new BlockPos(hitVec3i);
 			makeStacksTransparent(player, hit);
 
+			//? if >=1.20 {
 			boolean replaceable = player.level().getBlockState(hit)
+			//?} else {
+			/*boolean replaceable = player.level.getBlockState(hit)
+			*///?}
 				.canBeReplaced(new BlockPlaceContext(new UseOnContext(player, InteractionHand.MAIN_HAND, trace)));
 			if (trace.getDirection()
 				.getAxis()

--- a/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/IComposerTool.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/compose/planner/IComposerTool.java
@@ -13,8 +13,10 @@ import net.minecraft.client.input.KeyEvent;
 //?} else if >=1.21.10 {
 /*import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.input.KeyEvent;
-*///?} else {
+*///?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import org.apache.commons.lang3.ArrayUtils;
 import org.lwjgl.glfw.GLFW;

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignExporter.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignExporter.java
@@ -201,7 +201,11 @@ public class DesignExporter {
 		if (worldIn.getBlockState(signPos)
 			.getBlock() == Blocks.SPRUCE_SIGN) {
 			SignBlockEntity sign = (SignBlockEntity) worldIn.getBlockEntity(signPos);
+			//? if >=1.20 {
 			filename = sign.getFrontText().toString();
+			//?} else {
+			/*filename = sign.getMessage(1, false).getString();
+			*///?}
 			designPath = typePath + "/" + filename;
 
 		} else {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignResourceLoader.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignResourceLoader.java
@@ -5,7 +5,12 @@ import com.timmie.mightyarchitect.control.design.partials.Design;
 import com.timmie.mightyarchitect.foundation.utility.FilesHelper;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
+// NbtIo.readCompressed gained the NbtAccounter size guard in 1.20.3.
+//? if >=1.20.3 {
 import net.minecraft.nbt.NbtAccounter;
+//?} else {
+/*
+*///?}
 import net.minecraft.nbt.NbtIo;
 
 import java.io.IOException;
@@ -76,7 +81,11 @@ public class DesignResourceLoader {
 			try {
 				InputStream inputStream = Files.newInputStream(Paths.get("themes/" + theme.getFilePath()),
 						StandardOpenOption.READ);
+				//? if >=1.20.3 {
 				importedThemeFile = NbtIo.readCompressed(inputStream, NbtAccounter.unlimitedHeap());
+				//?} else {
+				/*importedThemeFile = NbtIo.readCompressed(inputStream);
+				*///?}
 				inputStream.close();
 			} catch (IOException e) {
 				e.printStackTrace();

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
@@ -205,7 +205,11 @@ public class ThemeStorage {
 						try {
 							InputStream inputStream = Files.newInputStream(Paths.get(folderPath + "/" + themeFolder),
 								StandardOpenOption.READ);
+							//? if >=1.20.3 {
 							themeFile = NbtIo.readCompressed(inputStream, NbtAccounter.unlimitedHeap());
+							//?} else {
+							/*themeFile = NbtIo.readCompressed(inputStream);
+							*///?}
 							inputStream.close();
 						} catch (IOException e) {
 							e.printStackTrace();

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/partials/Design.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/partials/Design.java
@@ -37,9 +37,16 @@ public abstract class Design {
 		} else if (compound.get("Size") instanceof CompoundTag) { // CompoundTag (old format)
 			CompoundTag sizeTag = compound.getCompound("Size").orElse(new CompoundTag());
 			size = new BlockPos(sizeTag.getInt("X").orElse(0), sizeTag.getInt("Y").orElse(0), sizeTag.getInt("Z").orElse(0));
-		//?} else {
+		//?} else if >=1.20.5 {
 		/*if (compound.contains("Size", 11)) { // 11 = IntArrayTag (new format)
 			size = NbtUtils.readBlockPos(compound, "Size").orElse(BlockPos.ZERO);
+		} else if (compound.contains("Size", 10)) { // 10 = CompoundTag (old format)
+			CompoundTag sizeTag = compound.getCompound("Size");
+			size = new BlockPos(sizeTag.getInt("X"), sizeTag.getInt("Y"), sizeTag.getInt("Z"));
+		*///?} else {
+		/*if (compound.contains("Size", 11)) { // 11 = IntArrayTag (new format)
+			int[] arr = compound.getIntArray("Size");
+			size = arr.length >= 3 ? new BlockPos(arr[0], arr[1], arr[2]) : BlockPos.ZERO;
 		} else if (compound.contains("Size", 10)) { // 10 = CompoundTag (old format)
 			CompoundTag sizeTag = compound.getCompound("Size");
 			size = new BlockPos(sizeTag.getInt("X"), sizeTag.getInt("Y"), sizeTag.getInt("Z"));

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/IRenderGameOverlay.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/IRenderGameOverlay.java
@@ -8,10 +8,19 @@ public interface IRenderGameOverlay {
 	void renderGameOverlay(GuiGraphicsExtractor ms, float partialTicks);
 	
 }
-//?} else {
+//?} else if >=1.20 {
 /*package com.timmie.mightyarchitect.control.phase;
 
 import net.minecraft.client.gui.GuiGraphics;
+
+public interface IRenderGameOverlay {
+
+	void renderGameOverlay(GuiGraphics ms, float partialTicks);
+	
+}*///?} else {
+/*package com.timmie.mightyarchitect.control.phase;
+
+import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 
 public interface IRenderGameOverlay {
 

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/PhaseComposing.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/PhaseComposing.java
@@ -16,8 +16,10 @@ import net.minecraft.client.input.KeyEvent;
 //?} else if >=1.21.10 {
 /*import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.input.KeyEvent;
-*///?} else {
+*///?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import com.timmie.mightyarchitect.foundation.MightyBuffers;
 import org.apache.commons.lang3.ArrayUtils;
@@ -147,8 +149,10 @@ public class PhaseComposing extends PhaseBase implements IRenderGameOverlay {
 		toolSelection.renderPassive(ms, Minecraft.getInstance()
 			//? if >=1.21.4 {
 			.getDeltaTracker().getGameTimeDeltaPartialTick(true));
-			//?} else {
+			//?} else if >=1.21 {
 			/*.getTimer().getGameTimeDeltaPartialTick(true));
+			*///?} else {
+			/*.getDeltaFrameTime());
 			*///?}
 		activeTool.getTool()
 			.renderOverlay(ms);

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/PhasePreviewing.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/PhasePreviewing.java
@@ -14,8 +14,10 @@ import net.minecraft.client.input.KeyEvent;
 //?} else if >=1.21.10 {
 /*import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.input.KeyEvent;
-*///?} else {
+*///?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import com.timmie.mightyarchitect.foundation.MightyBuffers;
 import org.apache.commons.lang3.ArrayUtils;

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/RenderTypes.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/RenderTypes.java
@@ -66,7 +66,7 @@ public class RenderTypes {
 						.setLightmapState(LIGHTMAP)
 						.setOverlayState(OVERLAY)
 						.createCompositeState(true));
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*public static RenderType getOutlineSolid(ResourceLocation texture) {
 		return RenderType.create(createLayerName("outline_solid"), DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256, true,
 				false, RenderType.CompositeState.builder()
@@ -75,6 +75,9 @@ public class RenderTypes {
 						.setLightmapState(LIGHTMAP)
 						.setOverlayState(OVERLAY)
 						.createCompositeState(true));
+	*///?} else {
+	/*public static RenderType getOutlineSolid(ResourceLocation texture) {
+		return RenderType.entityCutout(texture);
 	*///?}
 	}
 
@@ -104,7 +107,7 @@ public class RenderTypes {
 						.setOverlayState(OVERLAY)
 						.setWriteMaskState(RenderStateShard.COLOR_WRITE)
 						.createCompositeState(true));
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*public static RenderType getOutlineTranslucent(ResourceLocation texture, boolean cull) {
 		return RenderType.create(createLayerName("outline_translucent" + (cull ? "_cull" : "")),
 				DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256, true, true, RenderType.CompositeState.builder()
@@ -116,6 +119,9 @@ public class RenderTypes {
 						.setOverlayState(OVERLAY)
 						.setWriteMaskState(RenderStateShard.COLOR_WRITE)
 						.createCompositeState(true));
+	*///?} else {
+	/*public static RenderType getOutlineTranslucent(ResourceLocation texture, boolean cull) {
+		return RenderType.entityTranslucent(texture, !cull);
 	*///?}
 	}
 
@@ -134,7 +140,7 @@ public class RenderTypes {
 						.setLightmapState(LIGHTMAP)
 						.setOverlayState(OVERLAY)
 						.createCompositeState(true));
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*public static RenderType getGlowingSolid(ResourceLocation texture) {
 		return RenderType.create(createLayerName("glowing_solid"), DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256,
 				true, false, RenderType.CompositeState.builder()
@@ -143,6 +149,9 @@ public class RenderTypes {
 						.setLightmapState(LIGHTMAP)
 						.setOverlayState(OVERLAY)
 						.createCompositeState(true));
+	*///?} else {
+	/*public static RenderType getGlowingSolid(ResourceLocation texture) {
+		return RenderType.entitySolid(texture);
 	*///?}
 	}
 
@@ -176,7 +185,7 @@ public class RenderTypes {
 						.setLightmapState(LIGHTMAP)
 						.setOverlayState(OVERLAY)
 						.createCompositeState(true));
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*public static RenderType getGlowingTranslucent(ResourceLocation texture) {
 		return RenderType.create(createLayerName("glowing_translucent"), DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS,
 				256, true, true, RenderType.CompositeState.builder()
@@ -187,6 +196,9 @@ public class RenderTypes {
 						.setLightmapState(LIGHTMAP)
 						.setOverlayState(OVERLAY)
 						.createCompositeState(true));
+	*///?} else {
+	/*public static RenderType getGlowingTranslucent(ResourceLocation texture) {
+		return RenderType.entityTranslucent(texture);
 	*///?}
 	}
 
@@ -213,7 +225,7 @@ public class RenderTypes {
 			net.minecraft.client.renderer.rendertype.RenderTypes.entitySolid(TextureAtlas.LOCATION_BLOCKS);
 			//?} else if >=1.21.6 {
 			/*RenderType.entitySolid(TextureAtlas.LOCATION_BLOCKS);
-			*///?} else {
+			*///?} else if >=1.21 {
 			/*RenderType.create(createLayerName("item_partial_solid"), DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256, true,
 					false, RenderType.CompositeState.builder()
 							.setShaderState(RENDERTYPE_ENTITY_SOLID_SHADER)
@@ -222,6 +234,8 @@ public class RenderTypes {
 							.setLightmapState(LIGHTMAP)
 							.setOverlayState(OVERLAY)
 							.createCompositeState(true));
+			*///?} else {
+			/*RenderType.entitySolid(InventoryMenu.BLOCK_ATLAS);
 			*///?}
 
 	public static RenderType getItemPartialSolid() {
@@ -236,7 +250,7 @@ public class RenderTypes {
 	/*@SuppressWarnings("deprecation")
 	private static final RenderType ITEM_PARTIAL_TRANSLUCENT =
 			RenderType.entityTranslucent(TextureAtlas.LOCATION_BLOCKS);
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*private static final RenderType ITEM_PARTIAL_TRANSLUCENT = RenderType.create(createLayerName("item_partial_translucent"),
 			DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256, true, true, RenderType.CompositeState.builder()
 					.setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_SHADER)
@@ -245,6 +259,9 @@ public class RenderTypes {
 					.setLightmapState(LIGHTMAP)
 					.setOverlayState(OVERLAY)
 					.createCompositeState(true));
+	*///?} else {
+	/*private static final RenderType ITEM_PARTIAL_TRANSLUCENT =
+			RenderType.entityTranslucent(InventoryMenu.BLOCK_ATLAS);
 	*///?}
 
 	public static RenderType getItemPartialTranslucent() {
@@ -259,7 +276,7 @@ public class RenderTypes {
 	/*@SuppressWarnings("deprecation")
 	private static final RenderType FLUID =
 			RenderType.entityTranslucent(TextureAtlas.LOCATION_BLOCKS);
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*private static final RenderType FLUID = RenderType.create(createLayerName("fluid"),
 			DefaultVertexFormat.NEW_ENTITY, VertexFormat.Mode.QUADS, 256, true, true, RenderType.CompositeState.builder()
 					.setShaderState(RENDERTYPE_ENTITY_TRANSLUCENT_SHADER)
@@ -268,6 +285,8 @@ public class RenderTypes {
 					.setLightmapState(LIGHTMAP)
 					.setOverlayState(OVERLAY)
 					.createCompositeState(true));
+	*///?} else {
+	/*private static final RenderType FLUID = RenderType.entityTranslucent(InventoryMenu.BLOCK_ATLAS);
 	*///?}
 
 	public static RenderType getFluid() {

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperByteBuffer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperByteBuffer.java
@@ -1,6 +1,10 @@
 package com.timmie.mightyarchitect.foundation;
 
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.MeshData;
+//?} else {
+/*import com.mojang.blaze3d.vertex.BufferBuilder;
+*///?}
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 //? if >=26 {
@@ -72,10 +76,18 @@ public class SuperByteBuffer {
 	}
 
 	//*
-	 //* Constructs a SuperByteBuffer from MeshData (1.21.1+ API)
+	 //* Constructs a SuperByteBuffer from the renderer's finished mesh. 1.21+ hands out MeshData;
+	 //* the older versions hand out BufferBuilder.RenderedBuffer. Both expose the same draw state
+	 //* (vertex count + format) and a raw little-endian vertex ByteBuffer, so only the parameter
+	 //* type and the draw-state accessor differ.
 	 //
+	//? if >=1.21 {
 	public SuperByteBuffer(MeshData meshData) {
 		if (meshData == null) {
+	//?} else {
+	/*public SuperByteBuffer(BufferBuilder.RenderedBuffer meshData) {
+		if (meshData == null) {
+	*///?}
 			this.vertexData = new int[0];
 			this.vertexCount = 0;
 			this.formatSize = DEFAULT_VERTEX_SIZE;
@@ -84,7 +96,11 @@ public class SuperByteBuffer {
 			return;
 		}
 
+		//? if >=1.21 {
 		MeshData.DrawState drawState = meshData.drawState();
+		//?} else {
+		/*BufferBuilder.DrawState drawState = meshData.drawState();
+		*///?}
 		this.vertexCount = drawState.vertexCount();
 		//? if >=26 {
 		VertexFormat format = drawState.format();
@@ -153,49 +169,71 @@ public class SuperByteBuffer {
 			pos.mul(t);
 			lightPos.mul(localTransforms);
 
-			builder.addVertex(pos.x(), pos.y(), pos.z());
-
 			int color = getColor(i);
 			byte r = (byte) ((color >> 0) & 0xFF);
 			byte g = (byte) ((color >> 8) & 0xFF);
 			byte b = (byte) ((color >> 16) & 0xFF);
 			byte a = (byte) ((color >> 24) & 0xFF);
 
+			int outR, outG, outB, outA;
 			if (shouldColor) {
 				float lum = (r < 0 ? 255 + r : r) / 256f;
-				builder.setColor((int) (this.r * lum), (int) (this.g * lum), (int) (this.b * lum), this.a);
-			} else
-				builder.setColor(r & 0xFF, g & 0xFF, b & 0xFF, a & 0xFF);
+				outR = (int) (this.r * lum);
+				outG = (int) (this.g * lum);
+				outB = (int) (this.b * lum);
+				outA = this.a;
+			} else {
+				outR = r & 0xFF;
+				outG = g & 0xFF;
+				outB = b & 0xFF;
+				outA = a & 0xFF;
+			}
 
 			float u = getU(i);
 			float v = getV(i);
 
 			if (shouldShiftUV) {
-				float targetU = spriteShift.getTarget()
-					.getU((getUnInterpolatedU(spriteShift.getOriginal(), u) / sheetSize) + uTarget * 16);
-				float targetV = spriteShift.getTarget()
-					.getV((getUnInterpolatedV(spriteShift.getOriginal(), v) / sheetSize) + vTarget * 16);
-				builder.setUv(targetU, targetV);
-			} else
-				builder.setUv(u, v);
+				u = spriteShift.getTarget()
+					.getU((getUnInterpolatedU(spriteShift.getOriginal(), getU(i)) / sheetSize) + uTarget * 16);
+				v = spriteShift.getTarget()
+					.getV((getUnInterpolatedV(spriteShift.getOriginal(), getV(i)) / sheetSize) + vTarget * 16);
+			}
 
-			builder.setOverlay(OverlayTexture.NO_OVERLAY);
-
+			int light;
 			if (shouldLight) {
-				int light = packedLightCoords;
+				light = packedLightCoords;
 				if (lightTransform != null) {
 					lightPos.mul(lightTransform);
 					light = getLight(Minecraft.getInstance().level, lightPos);
 				}
-				builder.setLight(light);
 			} else
-				builder.setLight(getLightData(i));
+				light = getLightData(i);
+
+			// 1.21 replaced the chained-and-terminated VertexConsumer builder (vertex(...)...endVertex())
+			// with stateful setters that implicitly finish the previous vertex.
+			//? if >=1.21 {
+			builder.addVertex(pos.x(), pos.y(), pos.z());
+			builder.setColor(outR, outG, outB, outA);
+			builder.setUv(u, v);
+			builder.setOverlay(OverlayTexture.NO_OVERLAY);
+			builder.setLight(light);
+			//?} else {
+			/*builder.vertex(pos.x(), pos.y(), pos.z())
+				.color(outR, outG, outB, outA)
+				.uv(u, v)
+				.overlayCoords(OverlayTexture.NO_OVERLAY)
+				.uv2(light)
+				.normal(getNX(i), getNY(i), getNZ(i))
+				.endVertex();
+			*///?}
 
 			//? if >=26 {
 			if (hasNormal)
 				builder.setNormal(getNX(i), getNY(i), getNZ(i));
-			//?} else {
+			//?} else if >=1.21 {
 			/*builder.setNormal(getNX(i), getNY(i), getNZ(i));
+			*///?} else {
+			/*
 			*///?}
 		}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperByteBufferCache.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperByteBufferCache.java
@@ -3,9 +3,17 @@ package com.timmie.mightyarchitect.foundation;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.mojang.blaze3d.vertex.BufferBuilder;
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+//?} else {
+/*
+*///?}
 import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.MeshData;
+//?} else {
+/*
+*///?}
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.Minecraft;
@@ -116,8 +124,13 @@ public class SuperByteBufferCache {
 		BlockRenderDispatcher dispatcher = Minecraft.getInstance().getBlockRenderer();
 		ModelBlockRenderer blockRenderer = dispatcher.getModelRenderer();
 	*///?}
+		//? if >=1.21 {
 		ByteBufferBuilder byteBuffer = new ByteBufferBuilder(2097152);
 		BufferBuilder builder = com.timmie.mightyarchitect.foundation.compat.McCompat.quadBuffer(byteBuffer, DefaultVertexFormat.BLOCK);
+		//?} else {
+		/*BufferBuilder builder = new BufferBuilder(DefaultVertexFormat.BLOCK.getIntegerSize());
+		builder.begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.BLOCK);
+		*///?}
 		//? if >=26 {
 		BlockPos pos = BlockPos.ZERO;
 		BlockAndTintGetter blockAccess = singleBlockAccess(minecraft, referenceState, pos);
@@ -141,11 +154,17 @@ public class SuperByteBufferCache {
 		blockRenderer.tesselateBlock(Minecraft.getInstance().level, model, referenceState, BlockPos.ZERO.above(255), ms,
 				builder, true, random, 42, OverlayTexture.NO_OVERLAY);
 		*///?}
+		//? if >=1.21 {
 		MeshData meshData = builder.build();
 
 		SuperByteBuffer result = meshData != null ? new SuperByteBuffer(meshData) : SuperByteBuffer.empty();
 		byteBuffer.close();
 		return result;
+		//?} else {
+		/*var renderedBuffer = builder.end();
+
+		return renderedBuffer != null ? new SuperByteBuffer(renderedBuffer) : SuperByteBuffer.empty();
+		*///?}
 	}
 
 	//? if >=26 {

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperRenderTypeBuffer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperRenderTypeBuffer.java
@@ -270,7 +270,11 @@ public class SuperRenderTypeBuffer implements MightyBuffers {
 *///?} else {
 package com.timmie.mightyarchitect.foundation;
 
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+//?} else {
+/*import com.mojang.blaze3d.vertex.BufferBuilder;
+*///?}
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
 //? if >=1.21.11 {
@@ -287,7 +291,11 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.resources.model.ModelBakery;
 
+//? if >=1.21 {
 import java.util.SequencedMap;
+//?} else {
+/*import java.util.SortedMap;
+*///?}
 
 public class SuperRenderTypeBuffer implements MultiBufferSource, MightyBuffers {
 
@@ -336,7 +344,13 @@ public class SuperRenderTypeBuffer implements MultiBufferSource, MightyBuffers {
 
 	private static class SuperRenderTypeBufferPhase {
 
+		// 1.21 swapped the immediate-mode buffer pool from BufferBuilder to ByteBufferBuilder and
+		// the map type from fastutil's SortedMap view to SequencedMap.
+		//? if >=1.21 {
 		private final SequencedMap<RenderType, ByteBufferBuilder> fixedBuffers = Util.make(new Object2ObjectLinkedOpenHashMap<>(), map -> {
+		//?} else {
+		/*private final SortedMap<RenderType, BufferBuilder> fixedBuffers = Util.make(new Object2ObjectLinkedOpenHashMap<>(), map -> {
+		*///?}
 			//? if >=26 {
 			put(map, net.minecraft.client.renderer.rendertype.RenderTypes.solidMovingBlock());
 			put(map, net.minecraft.client.renderer.rendertype.RenderTypes.cutoutMovingBlock());
@@ -404,11 +418,19 @@ public class SuperRenderTypeBuffer implements MultiBufferSource, MightyBuffers {
 				put(map, p_173062_);
 			});
 		});
+		//? if >=1.21 {
 		private final BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new ByteBufferBuilder(256));
 
 		private static void put(Object2ObjectLinkedOpenHashMap<RenderType, ByteBufferBuilder> map, RenderType type) {
 			map.put(type, new ByteBufferBuilder(type.bufferSize()));
 		}
+		//?} else {
+		/*private final BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new BufferBuilder(256));
+
+		private static void put(Object2ObjectLinkedOpenHashMap<RenderType, BufferBuilder> map, RenderType type) {
+			map.put(type, new BufferBuilder(type.bufferSize()));
+		}
+		*///?}
 
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/WrappedWorld.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/WrappedWorld.java
@@ -16,7 +16,12 @@ import net.minecraft.world.clock.ClockManager;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.flag.FeatureFlagSet;
+// Brewing recipes and the MapId wrapper only exist from 1.20.5 onward.
+//? if >=1.20.5 {
 import net.minecraft.world.item.alchemy.PotionBrewing;
+//?} else {
+/*
+*///?}
 //? if >=26 {
 import net.minecraft.world.item.crafting.RecipeAccess;
 import net.minecraft.world.level.CardinalLighting;
@@ -46,14 +51,23 @@ import net.minecraft.world.level.entity.EntityTypeTest;
 import net.minecraft.world.level.entity.LevelEntityGetter;
 import net.minecraft.world.level.gameevent.GameEvent;
 import net.minecraft.world.level.material.Fluid;
+//? if >=1.20.5 {
 import net.minecraft.world.level.saveddata.maps.MapId;
+//?} else {
+/*
+*///?}
 import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
 import net.minecraft.world.level.storage.WritableLevelData;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.world.scores.Scoreboard;
 import net.minecraft.world.ticks.LevelTickAccess;
+// TickRateManager (the /tick command) arrived in 1.20.3.
+//? if >=1.20.3 {
 import net.minecraft.world.TickRateManager;
+//?} else {
+/*
+*///?}
 
 //? if >=1.21.6 {
 //?} else {
@@ -199,7 +213,12 @@ public class WrappedWorld extends Level implements BlockAndTintGetter {
 	*///?}
 
 	@Override
+	// GameEvent became registry-held (Holder) in 1.20.5.
+	//? if >=1.20.5 {
 	public void gameEvent(Holder<GameEvent> gameEvent, Vec3 vec3, GameEvent.Context context) {
+	//?} else {
+	/*public void gameEvent(GameEvent gameEvent, Vec3 vec3, GameEvent.Context context) {
+	*///?}
 
 	}
 
@@ -214,10 +233,13 @@ public class WrappedWorld extends Level implements BlockAndTintGetter {
 	}
 
 	@Override
+	// Level only started carrying the Holder<SoundEvent> overload in 1.21.
 	//? if >=1.21.6 {
 	public void playSound(@Nullable Entity source, double x, double y, double z, Holder<SoundEvent> soundIn, SoundSource category,
-	//?} else {
+	//?} else if >=1.21 {
 	/*public void playSound(@Nullable Player player, double x, double y, double z, Holder<SoundEvent> soundIn, SoundSource category,
+	*///?} else {
+	/*public void playSound(@Nullable Player player, double x, double y, double z, SoundEvent soundIn, SoundSource category,
 	*///?}
 		float volume, float pitch) {}
 
@@ -248,7 +270,12 @@ public class WrappedWorld extends Level implements BlockAndTintGetter {
 	}
 
 	@Override
+	// The map identifier became a MapId record in 1.20.5.
+	//? if >=1.20.5 {
 	public MapItemSavedData getMapData(MapId mapId) {
+	//?} else {
+	/*public MapItemSavedData getMapData(String mapName) {
+	*///?}
 		return null;
 	}
 
@@ -262,17 +289,22 @@ public class WrappedWorld extends Level implements BlockAndTintGetter {
 	@Override
 	//? if >=1.21.6 {
 	public void destroyBlockProgress(int breakerId, BlockPos pos, int progress) {}
-	//?} else {
+	//?} else if >=1.20.5 {
 	/*public void setMapData(MapId mapId, MapItemSavedData mapDataIn) {}
+	*///?} else {
+	/*public void setMapData(String mapId, MapItemSavedData mapDataIn) {}
 	*///?}
 
 	@Override
 	//? if >=1.21.6 {
 	public Scoreboard getScoreboard() {
 		return world.getScoreboard();
-	//?} else {
+	//?} else if >=1.20.5 {
 	/*public MapId getFreeMapId() {
 		return new MapId(0);
+	*///?} else {
+	/*public int getFreeMapId() {
+		return 0;
 	*///?}
 	}
 
@@ -374,15 +406,24 @@ public class WrappedWorld extends Level implements BlockAndTintGetter {
 		return world.enabledFeatures();
 	}
 
+	// PotionBrewing moved onto Level in 1.20.5; TickRateManager arrived with the /tick command in 1.20.3.
+	//? if >=1.20.5 {
 	@Override
 	public PotionBrewing potionBrewing() {
 		return world.potionBrewing();
 	}
+	//?} else {
+	/*
+	*///?}
 
+	//? if >=1.20.3 {
 	@Override
 	public TickRateManager tickRateManager() {
 		return world.tickRateManager();
 	}
+	//?} else {
+	/*
+	*///?}
 
 	@Override
 	//? if >=26 {

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
@@ -2,7 +2,11 @@ package com.timmie.mightyarchitect.foundation.compat;
 
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.vertex.BufferBuilder;
+//? if >=1.21 {
 import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+//?} else {
+/*
+*///?}
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
@@ -79,12 +83,19 @@ public final class McCompat {
 		//?}
 	}
 
-	/** 26.2 replaced VertexFormat.Mode with com.mojang.blaze3d.PrimitiveTopology. */
-	public static BufferBuilder quadBuffer(ByteBufferBuilder byteBuffer, VertexFormat format) {
-		//? if >=26.2 {
-		/*return new BufferBuilder(byteBuffer, com.mojang.blaze3d.PrimitiveTopology.QUADS, format);
-		*///?} else {
-		return new BufferBuilder(byteBuffer, VertexFormat.Mode.QUADS, format);
-		//?}
+	// 26.2 replaced VertexFormat.Mode with com.mojang.blaze3d.PrimitiveTopology, and
+	// ByteBufferBuilder does not exist at all before 1.21 - those nodes build their BufferBuilder
+	// directly and never call this. The arms are flat because a guard cannot nest inside a
+	// commented one.
+	//? if >=26.2 {
+	/*public static BufferBuilder quadBuffer(ByteBufferBuilder byteBuffer, VertexFormat format) {
+		return new BufferBuilder(byteBuffer, com.mojang.blaze3d.PrimitiveTopology.QUADS, format);
 	}
+	*///?} else if >=1.21 {
+	public static BufferBuilder quadBuffer(ByteBufferBuilder byteBuffer, VertexFormat format) {
+		return new BufferBuilder(byteBuffer, VertexFormat.Mode.QUADS, format);
+	}
+	//?} else {
+	/*
+	*///?}
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/gui/GuiGraphics.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/gui/GuiGraphics.java
@@ -1,0 +1,85 @@
+//? if <1.20 {
+/*package com.timmie.mightyarchitect.foundation.gui;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiComponent;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.FormattedCharSequence;
+
+public class GuiGraphics {
+
+	private final PoseStack pose;
+
+	public GuiGraphics(PoseStack pose) {
+		this.pose = pose;
+	}
+
+	public PoseStack pose() {
+		return pose;
+	}
+
+	public int guiWidth() {
+		return Minecraft.getInstance().getWindow().getGuiScaledWidth();
+	}
+
+	public int guiHeight() {
+		return Minecraft.getInstance().getWindow().getGuiScaledHeight();
+	}
+
+	public int drawString(Font font, String text, int x, int y, int color) {
+		return drawString(font, text, x, y, color, true);
+	}
+
+	public int drawString(Font font, String text, int x, int y, int color, boolean shadow) {
+		return shadow ? font.drawShadow(pose, text, x, y, color) : font.draw(pose, text, x, y, color);
+	}
+
+	public int drawString(Font font, Component text, int x, int y, int color) {
+		return drawString(font, text, x, y, color, true);
+	}
+
+	public int drawString(Font font, Component text, int x, int y, int color, boolean shadow) {
+		return shadow ? font.drawShadow(pose, text, x, y, color) : font.draw(pose, text, x, y, color);
+	}
+
+	public int drawString(Font font, FormattedCharSequence text, int x, int y, int color) {
+		return drawString(font, text, x, y, color, true);
+	}
+
+	public int drawString(Font font, FormattedCharSequence text, int x, int y, int color, boolean shadow) {
+		return shadow ? font.drawShadow(pose, text, x, y, color) : font.draw(pose, text, x, y, color);
+	}
+
+	public void drawCenteredString(Font font, String text, int x, int y, int color) {
+		GuiComponent.drawCenteredString(pose, font, text, x, y, color);
+	}
+
+	public void drawCenteredString(Font font, Component text, int x, int y, int color) {
+		GuiComponent.drawCenteredString(pose, font, text, x, y, color);
+	}
+
+	public void drawCenteredString(Font font, FormattedCharSequence text, int x, int y, int color) {
+		GuiComponent.drawCenteredString(pose, font, text, x, y, color);
+	}
+
+	public void fill(int minX, int minY, int maxX, int maxY, int color) {
+		GuiComponent.fill(pose, minX, minY, maxX, maxY, color);
+	}
+
+	public void blit(ResourceLocation texture, int x, int y, int u, int v, int width, int height) {
+		blit(texture, x, y, u, v, width, height, 256, 256);
+	}
+
+	public void blit(ResourceLocation texture, int x, int y, int u, int v, int width, int height,
+		int textureWidth, int textureHeight) {
+		RenderSystem.setShader(GameRenderer::getPositionTexShader);
+		RenderSystem.setShaderTexture(0, texture);
+		GuiComponent.blit(pose, x, y, (float) u, (float) v, width, height, textureWidth, textureHeight);
+	}
+}
+*///?}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/AnimationTickHolder.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/AnimationTickHolder.java
@@ -13,8 +13,10 @@ public class AnimationTickHolder {
 	public static float getRenderTick() {
 		//? if >=1.21.4 {
 		return ticks + Minecraft.getInstance().getDeltaTracker().getGameTimeDeltaPartialTick(true);
-		//?} else {
+		//?} else if >=1.21 {
 		/*return ticks + Minecraft.getInstance().getTimer().getGameTimeDeltaPartialTick(true);
+		*///?} else {
+		/*return ticks + Minecraft.getInstance().getFrameTime();
 		*///?}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/HudTextBuffer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/HudTextBuffer.java
@@ -89,7 +89,7 @@ public class HudTextBuffer {
 		}
 	}
 }
-//?} else {
+//?} else if >=1.21 {
 /*package com.timmie.mightyarchitect.foundation.utility;
 
 import net.minecraft.client.Camera;
@@ -151,6 +151,192 @@ public class HudTextBuffer {
 		Matrix4f projectionView = new Matrix4f()
 			.perspective(fovRad, aspect, 0.05f, 1000.0f)
 			.mul(new Matrix4f().rotation(camera.rotation()).invert());
+
+		for (Entry entry : ENTRIES) {
+			Vector4f clip = projectionView.transform(new Vector4f(
+				(float) (entry.pos().x - cameraPos.x),
+				(float) (entry.pos().y - cameraPos.y),
+				(float) (entry.pos().z - cameraPos.z),
+				1.0f));
+
+			if (clip.w() <= 0.0001f)
+				continue; // behind the camera
+
+			float ndcX = clip.x() / clip.w();
+			float ndcY = clip.y() / clip.w();
+			if (ndcX < -1.3f || ndcX > 1.3f || ndcY < -1.3f || ndcY > 1.3f)
+				continue; // well off-screen
+
+			float screenX = (ndcX * 0.5f + 0.5f) * guiWidth;
+			float screenY = (1.0f - (ndcY * 0.5f + 0.5f)) * guiHeight;
+
+			int width = font.width(entry.text());
+			int x = Math.round(screenX - width / 2.0f);
+			int y = Math.round(screenY - font.lineHeight / 2.0f);
+
+			gfx.fill(x - 2, y - 2, x + width + 2, y + font.lineHeight, ColorHelper.labelBackdrop(entry.color()));
+			gfx.drawString(font, entry.text(), x, y, entry.color(), false);
+		}
+	}
+}
+*///?} else if >=1.20 {
+/*package com.timmie.mightyarchitect.foundation.utility;
+
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
+import org.joml.Vector4f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// World-space text (measurement labels) is submitted here during the world render pass and drawn
+// as HUD text during the overlay pass.
+//
+// Immediate-mode Font.drawInBatch into a custom MultiBufferSource draws a label's backing geometry
+// but never its glyphs, so the labels are projected from their world position to screen
+// coordinates and rendered with the GUI text system, which does work.
+public class HudTextBuffer {
+
+	private record Entry(Vec3 pos, String text, int color) {}
+
+	private static final List<Entry> ENTRIES = new ArrayList<>();
+	private static Vec3 cameraPos = Vec3.ZERO;
+
+	// Clear the buffer at the start of a world render frame.
+	public static void beginFrame(Vec3 camera) {
+		ENTRIES.clear();
+		cameraPos = camera;
+	}
+
+	// Submit a world-space label to be drawn as HUD text this frame.
+	public static void submit(Vec3 worldPos, String text, int color) {
+		if (text == null || text.isEmpty())
+			return;
+		ENTRIES.add(new Entry(worldPos, text, color));
+	}
+
+	// Draw all submitted labels, projecting each world position to the screen.
+	public static void render(GuiGraphics gfx) {
+		if (ENTRIES.isEmpty())
+			return;
+
+		Minecraft mc = Minecraft.getInstance();
+		Font font = mc.font;
+		Camera camera = mc.gameRenderer.getMainCamera();
+
+		int guiWidth = gfx.guiWidth();
+		int guiHeight = gfx.guiHeight();
+		int pxWidth = mc.getWindow().getWidth();
+		int pxHeight = mc.getWindow().getHeight();
+		if (pxWidth <= 0 || pxHeight <= 0)
+			return;
+
+		float aspect = (float) pxWidth / (float) pxHeight;
+		float fovRad = (float) Math.toRadians(mc.options.fov().get());
+		// Before 1.21, Camera.rotation() does not carry the 180 degree flip that turns Minecraft's
+		// world-space heading into the -Z-forward eye space, so build the view rotation the way
+		// GameRenderer.renderLevel does: pitch about X, then yaw + 180 about Y.
+		Matrix4f projectionView = new Matrix4f()
+			.perspective(fovRad, aspect, 0.05f, 1000.0f)
+			.rotateX(camera.getXRot() * ((float) Math.PI / 180f))
+			.rotateY((camera.getYRot() + 180.0f) * ((float) Math.PI / 180f));
+
+		for (Entry entry : ENTRIES) {
+			Vector4f clip = projectionView.transform(new Vector4f(
+				(float) (entry.pos().x - cameraPos.x),
+				(float) (entry.pos().y - cameraPos.y),
+				(float) (entry.pos().z - cameraPos.z),
+				1.0f));
+
+			if (clip.w() <= 0.0001f)
+				continue; // behind the camera
+
+			float ndcX = clip.x() / clip.w();
+			float ndcY = clip.y() / clip.w();
+			if (ndcX < -1.3f || ndcX > 1.3f || ndcY < -1.3f || ndcY > 1.3f)
+				continue; // well off-screen
+
+			float screenX = (ndcX * 0.5f + 0.5f) * guiWidth;
+			float screenY = (1.0f - (ndcY * 0.5f + 0.5f)) * guiHeight;
+
+			int width = font.width(entry.text());
+			int x = Math.round(screenX - width / 2.0f);
+			int y = Math.round(screenY - font.lineHeight / 2.0f);
+
+			gfx.fill(x - 2, y - 2, x + width + 2, y + font.lineHeight, ColorHelper.labelBackdrop(entry.color()));
+			gfx.drawString(font, entry.text(), x, y, entry.color(), false);
+		}
+	}
+}
+*///?} else {
+/*package com.timmie.mightyarchitect.foundation.utility;
+
+import net.minecraft.client.Camera;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
+import org.joml.Vector4f;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// World-space text (measurement labels) is submitted here during the world render pass and drawn
+// as HUD text during the overlay pass.
+//
+// Immediate-mode Font.drawInBatch into a custom MultiBufferSource draws a label's backing geometry
+// but never its glyphs, so the labels are projected from their world position to screen
+// coordinates and rendered with the GUI text system, which does work.
+public class HudTextBuffer {
+
+	private record Entry(Vec3 pos, String text, int color) {}
+
+	private static final List<Entry> ENTRIES = new ArrayList<>();
+	private static Vec3 cameraPos = Vec3.ZERO;
+
+	// Clear the buffer at the start of a world render frame.
+	public static void beginFrame(Vec3 camera) {
+		ENTRIES.clear();
+		cameraPos = camera;
+	}
+
+	// Submit a world-space label to be drawn as HUD text this frame.
+	public static void submit(Vec3 worldPos, String text, int color) {
+		if (text == null || text.isEmpty())
+			return;
+		ENTRIES.add(new Entry(worldPos, text, color));
+	}
+
+	// Draw all submitted labels, projecting each world position to the screen.
+	public static void render(GuiGraphics gfx) {
+		if (ENTRIES.isEmpty())
+			return;
+
+		Minecraft mc = Minecraft.getInstance();
+		Font font = mc.font;
+		Camera camera = mc.gameRenderer.getMainCamera();
+
+		int guiWidth = gfx.guiWidth();
+		int guiHeight = gfx.guiHeight();
+		int pxWidth = mc.getWindow().getWidth();
+		int pxHeight = mc.getWindow().getHeight();
+		if (pxWidth <= 0 || pxHeight <= 0)
+			return;
+
+		float aspect = (float) pxWidth / (float) pxHeight;
+		float fovRad = (float) Math.toRadians(mc.options.fov().get());
+		// Before 1.21, Camera.rotation() does not carry the 180 degree flip that turns Minecraft's
+		// world-space heading into the -Z-forward eye space, so build the view rotation the way
+		// GameRenderer.renderLevel does: pitch about X, then yaw + 180 about Y.
+		Matrix4f projectionView = new Matrix4f()
+			.perspective(fovRad, aspect, 0.05f, 1000.0f)
+			.rotateX(camera.getXRot() * ((float) Math.PI / 180f))
+			.rotateY((camera.getYRot() + 180.0f) * ((float) Math.PI / 180f));
 
 		for (Entry entry : ENTRIES) {
 			Vector4f clip = projectionView.transform(new Vector4f(

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/LangBuilder.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/LangBuilder.java
@@ -150,8 +150,10 @@ public class LangBuilder {
 			.result()
 			.map(JsonElement::toString)
 			.orElse("");
-		//?} else {
+		//?} else if >=1.20.5 {
 		/*return Component.Serializer.toJson(component(), Minecraft.getInstance().level.registryAccess());
+		*///?} else {
+		/*return Component.Serializer.toJson(component());
 		*///?}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/Shaders.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/Shaders.java
@@ -59,9 +59,12 @@ public enum Shaders {
 			// ResourceLocation should just be namespace:name without path prefix or extension
 			location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, name);
 		}
-	*///?} else {
+	*///?} else if >=1.21 {
 	/*private Shaders(String filename) {
 		location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "shaders/post/" + filename);
+	*///?} else {
+	/*private Shaders(String filename) {
+		location = new ResourceLocation(TheMightyArchitect.ID, "shaders/post/" + filename);
 	*///?}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/ChasingAABBOutline.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/ChasingAABBOutline.java
@@ -32,8 +32,10 @@ public class ChasingAABBOutline extends AABBOutline {
 		renderBB(ms, buffer, interpolateBBs(prevBB, bb, Minecraft.getInstance()
 			//? if >=1.21.4 {
 			.getDeltaTracker().getGameTimeDeltaPartialTick(true)));
-			//?} else {
+			//?} else if >=1.21 {
 			/*.getTimer().getGameTimeDeltaPartialTick(true)));
+			*///?} else {
+			/*.getFrameTime()));
 			*///?}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/LineOutline.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/LineOutline.java
@@ -62,8 +62,10 @@ public class LineOutline extends Outline {
 			float pt = Minecraft.getInstance()
 				//? if >=1.21.4 {
 				.getDeltaTracker().getGameTimeDeltaPartialTick(true);
-				//?} else {
+				//?} else if >=1.21 {
 				/*.getTimer().getGameTimeDeltaPartialTick(true);
+				*///?} else {
+				/*.getFrameTime();
 				*///?}
 			renderCuboidLine(ms, buffer, VecHelper.lerp(prevStart, start, pt), VecHelper.lerp(prevEnd, end, pt));
 		}
@@ -96,8 +98,10 @@ public class LineOutline extends Outline {
 			float pt = Minecraft.getInstance()
 				//? if >=1.21.4 {
 				.getDeltaTracker().getGameTimeDeltaPartialTick(true);
-				//?} else {
+				//?} else if >=1.21 {
 				/*.getTimer().getGameTimeDeltaPartialTick(true);
+				*///?} else {
+				/*.getFrameTime();
 				*///?}
 			float distanceToTarget = 1 - Mth.lerp(pt, prevProgress, progress);
 			Vec3 start = end.add(this.start.subtract(end)

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/Outline.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/Outline.java
@@ -160,12 +160,32 @@ public abstract class Outline {
 		if (useFaceColor && params.faceRgb != null)
 			color = params.faceRgb;
 
+		// 1.21 renamed the VertexConsumer builder methods; 1.20.5 had already swapped the normal
+		// matrix argument for the whole Pose.
+		//? if >=1.21 {
 		builder.addVertex(peek.pose(), (float) pos.x, (float) pos.y, (float) pos.z)
 			.setColor((float) color.x, (float) color.y, (float) color.z, params.alpha)
 			.setUv(u, v)
 			.setOverlay(OverlayTexture.NO_OVERLAY)
 			.setLight(params.lightMap)
 			.setNormal(peek, xOffset, yOffset, zOffset);
+		//?} else if >=1.20.5 {
+		/*builder.vertex(peek.pose(), (float) pos.x, (float) pos.y, (float) pos.z)
+			.color((float) color.x, (float) color.y, (float) color.z, params.alpha)
+			.uv(u, v)
+			.overlayCoords(OverlayTexture.NO_OVERLAY)
+			.uv2(params.lightMap)
+			.normal(peek, xOffset, yOffset, zOffset)
+			.endVertex();
+		*///?} else {
+		/*builder.vertex(peek.pose(), (float) pos.x, (float) pos.y, (float) pos.z)
+			.color((float) color.x, (float) color.y, (float) color.z, params.alpha)
+			.uv(u, v)
+			.overlayCoords(OverlayTexture.NO_OVERLAY)
+			.uv2(params.lightMap)
+			.normal(peek.normal(), xOffset, yOffset, zOffset)
+			.endVertex();
+		*///?}
 
 		transformNormals = null;
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/OutlinedText.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/OutlinedText.java
@@ -54,8 +54,10 @@ public class OutlinedText extends Outline {
 		Minecraft mc = Minecraft.getInstance();
 		//? if >=1.21.4 {
 		float pt = mc.getDeltaTracker().getGameTimeDeltaPartialTick(true);
-		//?} else {
+		//?} else if >=1.21 {
 		/*float pt = mc.getTimer().getGameTimeDeltaPartialTick(true);
+		*///?} else {
+		/*float pt = mc.getFrameTime();
 		*///?}
 		Vec3 vec = VecHelper.lerp(prevLocation, location, pt);
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/Outliner.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/outliner/Outliner.java
@@ -165,8 +165,10 @@ public class Outliner {
 				float alpha = Mth.lerp(Minecraft.getInstance()
 					//? if >=1.21.4 {
 					.getDeltaTracker().getGameTimeDeltaPartialTick(true), lastAlpha, currentAlpha);
-					//?} else {
+					//?} else if >=1.21 {
 					/*.getTimer().getGameTimeDeltaPartialTick(true), lastAlpha, currentAlpha);
+					*///?} else {
+					/*.getFrameTime(), lastAlpha, currentAlpha);
 					*///?}
 
 				outline.params.alpha = alpha * alpha * alpha;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/AbstractSimiScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/AbstractSimiScreen.java
@@ -4,8 +4,10 @@ import com.timmie.mightyarchitect.gui.widgets.AbstractSimiWidget;
 import net.minecraft.client.Minecraft;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.Screen;
@@ -53,16 +55,25 @@ public abstract class AbstractSimiScreen extends Screen {
 		if (shouldRenderDarkBackground()) {
 			renderBackground(ms, mouseX, mouseY, partialTicks);
 		}
-	*///?} else {
+	*///?} else if >=1.20.2 {
 	/*public void render(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
 		renderBackground(ms, mouseX, mouseY, partialTicks);
+	*///?} else if >=1.20 {
+	/*public void render(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
+		renderBackground(ms);
+	*///?} else {
+	/*public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
+		GuiGraphics ms = new GuiGraphics(poseStack);
+		renderBackground(poseStack);
 	*///?}
 		renderWindow(ms, mouseX, mouseY, partialTicks);
 		for (AbstractWidget widget : widgets)
 			//? if >=26 {
 			widget.extractRenderState(ms, mouseX, mouseY, partialTicks);
-			//?} else {
+			//?} else if >=1.20 {
 			/*widget.render(ms, mouseX, mouseY, partialTicks);
+			*///?} else {
+			/*widget.render(ms.pose(), mouseX, mouseY, partialTicks);
 			*///?}
 		renderWindowForeground(ms, mouseX, mouseY, partialTicks);
 	}
@@ -146,12 +157,21 @@ public abstract class AbstractSimiScreen extends Screen {
 	}
 
 	@Override
+	//? if >=1.20.2 {
 	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
 		for (AbstractWidget widget : widgets) {
 			if (widget.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount))
 				return true;
 		}
 		return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
+	//?} else {
+	/*public boolean mouseScrolled(double mouseX, double mouseY, double verticalAmount) {
+		for (AbstractWidget widget : widgets) {
+			if (widget.mouseScrolled(mouseX, mouseY, verticalAmount))
+				return true;
+		}
+		return super.mouseScrolled(mouseX, mouseY, verticalAmount);
+	*///?}
 	}
 
 	@Override
@@ -197,9 +217,12 @@ public abstract class AbstractSimiScreen extends Screen {
 					.collect(java.util.stream.Collectors.toList());
 				ms.setTooltipForNextFrame(Minecraft.getInstance().font, tooltipLines, mouseX, mouseY);
 			}
-				*///?} else {
+				*///?} else if >=1.20 {
 				/*.isEmpty())
 				ms.renderComponentTooltip(Minecraft.getInstance().font, ((AbstractSimiWidget) widget).getToolTip(), mouseX, mouseY);
+				*///?} else {
+				/*.isEmpty())
+				renderComponentTooltip(ms.pose(), ((AbstractSimiWidget) widget).getToolTip(), mouseX, mouseY);
 				*///?}
 		}
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ArchitectMenuScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ArchitectMenuScreen.java
@@ -17,8 +17,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.screens.Screen;
 //? if >=1.21.10 {
@@ -100,10 +102,15 @@ public class ArchitectMenuScreen extends Screen {
 	/*public void render(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
 		// Don't call super.render() - we don't want the dark background overlay
 		// This is an in-game menu that should show over the game world
-	*///?} else {
+	*///?} else if >=1.20 {
 	/*public void render(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
 		// FOCUSED
 		super.render(ms, mouseX, mouseY, partialTicks);
+	*///?} else {
+	/*public void render(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
+		GuiGraphics ms = new GuiGraphics(poseStack);
+		// FOCUSED
+		super.render(poseStack, mouseX, mouseY, partialTicks);
 	*///?}
 		draw(ms, partialTicks);
 	}
@@ -218,8 +225,10 @@ public class ArchitectMenuScreen extends Screen {
 		Window mainWindow = mc.getWindow();
 		//? if >=1.21.4 {
 		partialTicks = mc.getDeltaTracker().getGameTimeDeltaPartialTick(true);
-		//?} else {
+		//?} else if >=1.21 {
 		/*partialTicks = mc.getTimer().getGameTimeDeltaPartialTick(true);
+		*///?} else {
+		/*partialTicks = mc.getFrameTime();
 		*///?}
 
 		int x = mainWindow.getGuiScaledWidth() - menuWidth - 10;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/DesignExporterScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/DesignExporterScreen.java
@@ -10,8 +10,9 @@ import com.timmie.mightyarchitect.gui.widgets.ScrollInput;
 import com.timmie.mightyarchitect.gui.widgets.SelectionScrollInput;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
-/*import net.minecraft.client.gui.GuiGraphics;*///?}
+//?} else if >=1.20 {
+/*import net.minecraft.client.gui.GuiGraphics;*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;*///?}
 
 import java.util.ArrayList;
 import java.util.List;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/GuiGameElement.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/GuiGameElement.java
@@ -50,8 +50,15 @@ import net.minecraft.client.renderer.entity.ItemRenderer;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.client.renderer.texture.TextureAtlas;
 import net.minecraft.client.resources.model.BakedModel;
-*///?} else {
+*///?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.block.BlockRenderDispatcher;
+import net.minecraft.client.renderer.entity.ItemRenderer;
+import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.client.resources.model.BakedModel;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.block.BlockRenderDispatcher;
 import net.minecraft.client.renderer.entity.ItemRenderer;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/PalettePickerScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/PalettePickerScreen.java
@@ -24,9 +24,12 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 //?} else if >=1.21.10 {
 /*import net.minecraft.client.gui.GuiGraphics;
-*///?} else {
+*///?} else if >=1.20 {
 /*import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import net.minecraft.client.gui.Gui;
+import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Tooltip;
@@ -367,9 +370,13 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 		//? if >=26 {
 		public void extractWidgetRenderState(GuiGraphicsExtractor ms, int mouseX, int mouseY, float partialTicks) {
 			super.extractWidgetRenderState(ms, mouseX, mouseY, partialTicks);
-		//?} else {
+		//?} else if >=1.20 {
 		/*public void renderWidget(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
 			super.renderWidget(ms, mouseX, mouseY, partialTicks);
+		*///?} else {
+		/*public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
+			super.renderWidget(poseStack, mouseX, mouseY, partialTicks);
+			GuiGraphics ms = new GuiGraphics(poseStack);
 		*///?}
 			preview(ms, minecraft);
 		}

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ScreenResources.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ScreenResources.java
@@ -22,8 +22,11 @@ import net.minecraft.resources.ResourceLocation;
 /*import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.resources.ResourceLocation;
-*///?} else {
+*///?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 import net.minecraft.resources.ResourceLocation;
 *///?}
 
@@ -137,8 +140,10 @@ public enum ScreenResources {
 
 	private ScreenResources(String location, int startX, int startY, int width, int height, int textureWidth, int textureHeight) {
 		this.location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "textures/gui/" + location);
-		*///?} else {
+		*///?} else if >=1.21 {
 		/*this.location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "textures/gui/" + location);
+		*///?} else {
+		/*this.location = new ResourceLocation(TheMightyArchitect.ID, "textures/gui/" + location);
 		*///?}
 		this.width = width; this.height = height;
 		this.startX = startX; this.startY = startY;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/TextInputPromptScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/TextInputPromptScreen.java
@@ -3,8 +3,10 @@ package com.timmie.mightyarchitect.gui;
 import com.timmie.mightyarchitect.foundation.compat.McCompat;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ThemeSettingsScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ThemeSettingsScreen.java
@@ -10,8 +10,9 @@ import com.timmie.mightyarchitect.gui.widgets.Label;
 import com.timmie.mightyarchitect.gui.widgets.ScrollInput;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
-/*import net.minecraft.client.gui.GuiGraphics;*///?}
+//?} else if >=1.20 {
+/*import net.minecraft.client.gui.GuiGraphics;*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;*///?}
 import net.minecraft.client.gui.components.EditBox;
 //? if >=1.21.10 {
 import net.minecraft.client.input.MouseButtonEvent;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ToolSelectionScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ToolSelectionScreen.java
@@ -15,8 +15,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.screens.Screen;
 //? if >=1.21.6 {

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/IconButton.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/IconButton.java
@@ -10,8 +10,10 @@ import com.mojang.blaze3d.vertex.PoseStack;
 import com.timmie.mightyarchitect.gui.ScreenResources;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 //? if >=1.21.10 {
@@ -39,8 +41,11 @@ public class IconButton extends AbstractSimiWidget {
 	@Override
 	//? if >=26 {
 	public void extractWidgetRenderState(GuiGraphicsExtractor ms, int mouseX, int mouseY, float partialTicks) {
-	//?} else {
+	//?} else if >=1.20 {
 	/*public void renderWidget(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
+	*///?} else {
+	/*public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
+		GuiGraphics ms = new GuiGraphics(poseStack);
 	*///?}
 		if (this.visible) {
 			this.isHovered =

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Indicator.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Indicator.java
@@ -8,8 +8,10 @@ import com.google.common.collect.ImmutableList;
 import com.timmie.mightyarchitect.gui.ScreenResources;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
@@ -36,8 +38,11 @@ public class Indicator extends AbstractSimiWidget {
 	@Override
 	//? if >=26 {
 	public void extractWidgetRenderState(GuiGraphicsExtractor ms, int mouseX, int mouseY, float partialTicks ) {
-	//?} else {
+	//?} else if >=1.20 {
 	/*public void renderWidget(GuiGraphics ms, int mouseX, int mouseY, float partialTicks ) {
+	*///?} else {
+	/*public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks ) {
+		GuiGraphics ms = new GuiGraphics(poseStack);
 	*///?}
 		ScreenResources toDraw;
 		switch(state) {

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Label.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Label.java
@@ -9,8 +9,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 import net.minecraft.network.chat.Component;
@@ -86,8 +88,11 @@ public class Label extends AbstractSimiWidget {
 	@Override
 	//? if >=26 {
 	public void extractWidgetRenderState(GuiGraphicsExtractor matrixStack, int mouseX, int mouseY, float partialTicks) {
-	//?} else {
+	//?} else if >=1.20 {
 	/*public void renderWidget(GuiGraphics matrixStack, int mouseX, int mouseY, float partialTicks) {
+	*///?} else {
+	/*public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int mouseX, int mouseY, float partialTicks) {
+		GuiGraphics matrixStack = new GuiGraphics(poseStack);
 	*///?}
 		if (!visible)
 			return;

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/ScrollInput.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/ScrollInput.java
@@ -8,8 +8,10 @@ import com.timmie.mightyarchitect.foundation.utility.Keyboard;
 import net.minecraft.ChatFormatting;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.narration.NarrationElementOutput;
 //? if >=1.21.10 {
@@ -90,7 +92,11 @@ public class ScrollInput extends AbstractSimiWidget {
 	}
 
 	@Override
+	//? if >=1.20.2 {
 	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
+	//?} else {
+	/*public boolean mouseScrolled(double mouseX, double mouseY, double verticalAmount) {
+	*///?}
 		if (!isHovered)
 			return false;
 
@@ -144,8 +150,10 @@ public class ScrollInput extends AbstractSimiWidget {
 	@Override
 	//? if >=26 {
 	public void extractWidgetRenderState(GuiGraphicsExtractor poseStack, int i, int j, float f) {
-	//?} else {
+	//?} else if >=1.20 {
 	/*public void renderWidget(GuiGraphics poseStack, int i, int j, float f) {
+	*///?} else {
+	/*public void renderWidget(com.mojang.blaze3d.vertex.PoseStack poseStack, int i, int j, float f) {
 	*///?}
 
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/SelectionScrollInput.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/SelectionScrollInput.java
@@ -30,8 +30,13 @@ public class SelectionScrollInput extends ScrollInput {
 	}
 
 	@Override
+	//? if >=1.20.2 {
 	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
 		return super.mouseScrolled(mouseX, mouseY, horizontalAmount, -verticalAmount);
+	//?} else {
+	/*public boolean mouseScrolled(double mouseX, double mouseY, double verticalAmount) {
+		return super.mouseScrolled(mouseX, mouseY, -verticalAmount);
+	*///?}
 	}
 
 	@Override

--- a/common/src/main/java/com/timmie/mightyarchitect/mixin/GuiMixin.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/mixin/GuiMixin.java
@@ -1,7 +1,11 @@
 package com.timmie.mightyarchitect.mixin;
 
 import com.timmie.mightyarchitect.platform.ClientHooks;
+//? if >=1.21 {
 import net.minecraft.client.DeltaTracker;
+//?} else {
+/*
+*///?}
 //? if >=26.2 {
 /*import net.minecraft.client.gui.Hud;
 *///?} else {
@@ -9,8 +13,10 @@ import net.minecraft.client.gui.Gui;
 //?}
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.mojang.blaze3d.vertex.PoseStack;
 *///?}
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -18,10 +24,13 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 /**
- * HUD hook, drawn after the vanilla overlay. 26.1 replaced the immediate GUI pass with render-state
- * extraction, which renamed both the method and its graphics type. 26.2 then split the HUD out of
- * Gui into its own class: Gui.extractRenderState became (DeltaTracker, boolean, boolean) and the
- * graphics-taking overload this hooks now lives on Hud.
+ * HUD hook, drawn after the vanilla overlay.
+ * <p>
+ * The target moves four times across the supported range: 1.20 replaced the raw PoseStack with
+ * GuiGraphics, 1.21 replaced the partial-tick float with DeltaTracker, 26.1 replaced the immediate
+ * GUI pass with render-state extraction (renaming both the method and its graphics type), and 26.2
+ * split the HUD out of Gui into its own class - Gui.extractRenderState became
+ * (DeltaTracker, boolean, boolean) and the graphics-taking overload this hooks now lives on Hud.
  */
 //? if >=26.2 {
 /*@Mixin(Hud.class)
@@ -34,11 +43,25 @@ public class GuiMixin {
 	@Inject(method = "extractRenderState", at = @At("TAIL"))
 	private void mightyarchitect$renderHud(GuiGraphicsExtractor graphics, DeltaTracker deltaTracker,
 		CallbackInfo ci) {
-	//?} else {
+		ClientHooks.renderHud(graphics, deltaTracker);
+	}
+	//?} else if >=1.21 {
 	/*@Inject(method = "render", at = @At("TAIL"))
 	private void mightyarchitect$renderHud(GuiGraphics graphics, DeltaTracker deltaTracker,
 		CallbackInfo ci) {
-	*///?}
 		ClientHooks.renderHud(graphics, deltaTracker);
 	}
+	*///?} else if >=1.20 {
+	/*@Inject(method = "render", at = @At("TAIL"))
+	private void mightyarchitect$renderHud(GuiGraphics graphics, float partialTicks,
+		CallbackInfo ci) {
+		ClientHooks.renderHud(graphics, partialTicks);
+	}
+	*///?} else {
+	/*@Inject(method = "render", at = @At("TAIL"))
+	private void mightyarchitect$renderHud(PoseStack poseStack, float partialTicks,
+		CallbackInfo ci) {
+		ClientHooks.renderHud(new com.timmie.mightyarchitect.foundation.gui.GuiGraphics(poseStack), partialTicks);
+	}
+	*///?}
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/InstantPrintPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/InstantPrintPacket.java
@@ -1,19 +1,28 @@
 package com.timmie.mightyarchitect.networking;
 
 import com.timmie.mightyarchitect.AllPackets;
+import com.timmie.mightyarchitect.platform.MightyPacket;
 import com.timmie.mightyarchitect.platform.PacketContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
+import net.minecraft.network.FriendlyByteBuf;
+// The buffer gained a registry-access view in 1.20.5, which is also when payloads stopped being
+// written through the interface and started going through a stream codec. RegistryFriendlyByteBuf
+// extends FriendlyByteBuf, so the writer itself is shared.
+//? if >=1.20.5 {
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+//?} else {
+/*import net.minecraft.resources.ResourceLocation;
+*///?}
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.*;
 
-public class InstantPrintPacket implements CustomPacketPayload {
+public class InstantPrintPacket implements MightyPacket {
 
 	private BunchOfBlocks blocks;
 
@@ -21,7 +30,11 @@ public class InstantPrintPacket implements CustomPacketPayload {
 		this.blocks = blocks;
 	}
 
+	//? if >=1.20.5 {
 	public InstantPrintPacket(RegistryFriendlyByteBuf buf) {
+	//?} else {
+	/*public InstantPrintPacket(FriendlyByteBuf buf) {
+	*///?}
 		// Store raw NBT data to decode on server side with proper registry
 		int size = buf.readInt();
 		this.blocks = new BunchOfBlocks(new HashMap<>());
@@ -36,11 +49,26 @@ public class InstantPrintPacket implements CustomPacketPayload {
 	}
 
 	@Override
+	//? if >=1.20.5 {
 	public Type<? extends CustomPacketPayload> type() {
 		return AllPackets.INSTANT_PRINT_TYPE;
 	}
 
 	public static void write(RegistryFriendlyByteBuf buf, InstantPrintPacket packet) {
+		writeTo(buf, packet);
+	}
+	//?} else {
+	/*public ResourceLocation id() {
+		return AllPackets.INSTANT_PRINT_ID;
+	}
+
+	@Override
+	public void write(FriendlyByteBuf buf) {
+		writeTo(buf, this);
+	}
+	*///?}
+
+	private static void writeTo(FriendlyByteBuf buf, InstantPrintPacket packet) {
 		buf.writeInt(packet.blocks.size);
 		packet.blocks.blocks.forEach((pos, state) -> {
 			buf.writeNbt(NbtUtils.writeBlockState(state));
@@ -49,7 +77,12 @@ public class InstantPrintPacket implements CustomPacketPayload {
 	}
 
 	public static void handle(InstantPrintPacket packet, PacketContext context) {
+		// Entity.level() replaced the public level field in 1.20.
+		//? if >=1.20 {
 		context.enqueue(() -> apply(context.player().level(), packet));
+		//?} else {
+		/*context.enqueue(() -> apply(context.player().level, packet));
+		*///?}
 	}
 
 	// Separated from handle so the automated server test can drive the same placement logic

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/PacketWire.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/PacketWire.java
@@ -1,0 +1,49 @@
+package com.timmie.mightyarchitect.networking;
+
+import com.timmie.mightyarchitect.AllPackets;
+import io.netty.buffer.Unpooled;
+import net.minecraft.core.RegistryAccess;
+//? if >=1.20.5 {
+import net.minecraft.network.RegistryFriendlyByteBuf;
+//?} else {
+/*import net.minecraft.network.FriendlyByteBuf;
+*///?}
+
+/**
+ * Serialises a packet and reads it straight back, the way the loader does on the wire.
+ * <p>
+ * This lives in {@code common/} rather than in the server-test companion because the wire format is
+ * genuinely version-variable - 1.20.5 introduced stream codecs and the registry-aware buffer, and
+ * everything older writes through the payload itself onto a plain buffer - while the test modules
+ * are not Stonecutter-processed and so have to stay version-agnostic.
+ */
+public final class PacketWire {
+
+	private PacketWire() {
+	}
+
+	/**
+	 * The outcome of one encode/decode cycle. A codec that writes and reads asymmetrically corrupts
+	 * every later field, so {@code unreadBytes} is the assertion that matters most.
+	 */
+	public record RoundTrip(InstantPrintPacket packet, int encodedBytes, int unreadBytes,
+		boolean identityMatches) {
+	}
+
+	public static RoundTrip roundTrip(RegistryAccess registries, InstantPrintPacket packet) {
+		//? if >=1.20.5 {
+		RegistryFriendlyByteBuf buffer = new RegistryFriendlyByteBuf(Unpooled.buffer(), registries);
+		AllPackets.INSTANT_PRINT_CODEC.encode(buffer, packet);
+		int encoded = buffer.readableBytes();
+		InstantPrintPacket decoded = AllPackets.INSTANT_PRINT_CODEC.decode(buffer);
+		boolean identity = decoded.type() == AllPackets.INSTANT_PRINT_TYPE;
+		//?} else {
+		/*FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer());
+		packet.write(buffer);
+		int encoded = buffer.readableBytes();
+		InstantPrintPacket decoded = AllPackets.INSTANT_PRINT_DECODER.apply(buffer);
+		boolean identity = decoded.id().equals(AllPackets.INSTANT_PRINT_ID);
+		*///?}
+		return new RoundTrip(decoded, encoded, buffer.readableBytes(), identity);
+	}
+}

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/PlaceSignPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/PlaceSignPacket.java
@@ -1,17 +1,31 @@
 package com.timmie.mightyarchitect.networking;
 
 import com.timmie.mightyarchitect.AllPackets;
+import com.timmie.mightyarchitect.platform.MightyPacket;
 import com.timmie.mightyarchitect.platform.PacketContext;
 import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+// The buffer gained a registry-access view in 1.20.5, which is also when payloads stopped being
+// written through the interface and started going through a stream codec. RegistryFriendlyByteBuf
+// extends FriendlyByteBuf, so the writer itself is shared.
+//? if >=1.20.5 {
 import net.minecraft.network.RegistryFriendlyByteBuf;
-import net.minecraft.network.chat.Component;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+//?} else {
+/*import net.minecraft.resources.ResourceLocation;
+*///?}
+import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
+// The SignText record, and the front/back text split it belongs to, arrived with the 1.20 sign rework.
+//? if >=1.20 {
 import net.minecraft.world.level.block.entity.SignText;
+//?} else {
+/*
+*///?}
 
-public class PlaceSignPacket implements CustomPacketPayload {
+public class PlaceSignPacket implements MightyPacket {
 
 	private final String text1;
 	private final String text2;
@@ -23,16 +37,35 @@ public class PlaceSignPacket implements CustomPacketPayload {
 		this.position = position;
 	}
 
+	//? if >=1.20.5 {
 	public PlaceSignPacket(RegistryFriendlyByteBuf buffer) {
+	//?} else {
+	/*public PlaceSignPacket(FriendlyByteBuf buffer) {
+	*///?}
 		this(buffer.readUtf(128), buffer.readUtf(128), buffer.readBlockPos());
 	}
 
 	@Override
+	//? if >=1.20.5 {
 	public Type<? extends CustomPacketPayload> type() {
 		return AllPackets.PLACE_SIGN_TYPE;
 	}
 
 	public static void write(RegistryFriendlyByteBuf buffer, PlaceSignPacket packet) {
+		writeTo(buffer, packet);
+	}
+	//?} else {
+	/*public ResourceLocation id() {
+		return AllPackets.PLACE_SIGN_ID;
+	}
+
+	@Override
+	public void write(FriendlyByteBuf buffer) {
+		writeTo(buffer, this);
+	}
+	*///?}
+
+	private static void writeTo(FriendlyByteBuf buffer, PlaceSignPacket packet) {
 		buffer.writeUtf(packet.text1);
 		buffer.writeUtf(packet.text2);
 		buffer.writeBlockPos(packet.position);
@@ -40,12 +73,23 @@ public class PlaceSignPacket implements CustomPacketPayload {
 
 	public static void handle(PlaceSignPacket packet, PacketContext context) {
 		context.enqueue(() -> {
+			// Entity.level() replaced the public level field in 1.20.
+			//? if >=1.20 {
 			Level entityWorld = context.player().level();
+			//?} else {
+			/*Level entityWorld = context.player().level;
+			*///?}
 			entityWorld.setBlockAndUpdate(packet.position, Blocks.SPRUCE_SIGN.defaultBlockState());
 			SignBlockEntity sign = (SignBlockEntity) entityWorld.getBlockEntity(packet.position);
 
 			if (sign != null) {
+				//? if >=1.20 {
 				sign.setText(new SignText().setMessage(0, Component.literal(packet.text1)).setMessage(1, Component.literal(packet.text2)), true);
+				//?} else {
+				/*sign.setMessage(0, Component.literal(packet.text1));
+				sign.setMessage(1, Component.literal(packet.text2));
+				sign.setChanged();
+				*///?}
 			}
 		});
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/SetHotbarItemPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/SetHotbarItemPacket.java
@@ -1,13 +1,22 @@
 package com.timmie.mightyarchitect.networking;
 
 import com.timmie.mightyarchitect.AllPackets;
+import com.timmie.mightyarchitect.platform.MightyPacket;
 import com.timmie.mightyarchitect.platform.PacketContext;
+import net.minecraft.network.FriendlyByteBuf;
+// The buffer gained a registry-access view in 1.20.5, which is also when payloads stopped being
+// written through the interface and started going through a stream codec. RegistryFriendlyByteBuf
+// extends FriendlyByteBuf, so the writer itself is shared.
+//? if >=1.20.5 {
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+//?} else {
+/*import net.minecraft.resources.ResourceLocation;
+*///?}
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 
-public class SetHotbarItemPacket implements CustomPacketPayload {
+public class SetHotbarItemPacket implements MightyPacket {
 
 	private final int slot;
 	private final ItemStack stack;
@@ -17,12 +26,22 @@ public class SetHotbarItemPacket implements CustomPacketPayload {
 		this.stack = stack;
 	}
 
+	// ItemStack's stream codec arrived with the data components in 1.20.5; before that the buffer
+	// carries the item itself.
+	//? if >=1.20.5 {
 	public SetHotbarItemPacket(RegistryFriendlyByteBuf buffer) {
 		this.slot = buffer.readInt();
 		this.stack = ItemStack.OPTIONAL_STREAM_CODEC.decode(buffer);
 	}
+	//?} else {
+	/*public SetHotbarItemPacket(FriendlyByteBuf buffer) {
+		this.slot = buffer.readInt();
+		this.stack = buffer.readItem();
+	}
+	*///?}
 
 	@Override
+	//? if >=1.20.5 {
 	public Type<? extends CustomPacketPayload> type() {
 		return AllPackets.SET_HOTBAR_ITEM_TYPE;
 	}
@@ -31,6 +50,17 @@ public class SetHotbarItemPacket implements CustomPacketPayload {
 		buffer.writeInt(packet.slot);
 		ItemStack.OPTIONAL_STREAM_CODEC.encode(buffer, packet.stack);
 	}
+	//?} else {
+	/*public ResourceLocation id() {
+		return AllPackets.SET_HOTBAR_ITEM_ID;
+	}
+
+	@Override
+	public void write(FriendlyByteBuf buffer) {
+		buffer.writeInt(slot);
+		buffer.writeItem(stack);
+	}
+	*///?}
 
 	public static void handle(SetHotbarItemPacket packet, PacketContext context) {
 		context.enqueue(() -> {

--- a/common/src/main/java/com/timmie/mightyarchitect/platform/ClientHooks.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/platform/ClientHooks.java
@@ -4,12 +4,21 @@ import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.control.ArchitectManager;
 import com.timmie.mightyarchitect.foundation.utility.ShaderManager;
 import com.timmie.mightyarchitect.gui.ScreenHelper;
+// DeltaTracker replaced the raw partial-tick float in 1.21, and GuiGraphics itself only exists
+// from 1.20 - before that the HUD is drawn straight onto a PoseStack, which the mod's own
+// GuiGraphics stand-in wraps.
+//? if >=1.21 {
 import net.minecraft.client.DeltaTracker;
+//?} else {
+/*
+*///?}
 import net.minecraft.client.Minecraft;
 //? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-//?} else {
+//?} else if >=1.20 {
 /*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 
 /**
@@ -36,11 +45,17 @@ public final class ClientHooks {
 
 	//? if >=26 {
 	public static void renderHud(GuiGraphicsExtractor graphics, DeltaTracker deltaTracker) {
-	//?} else {
-	/*public static void renderHud(GuiGraphics graphics, DeltaTracker deltaTracker) {
-	*///?}
 		ArchitectManager.onDrawGameOverlay(graphics, deltaTracker);
 	}
+	//?} else if >=1.21 {
+	/*public static void renderHud(GuiGraphics graphics, DeltaTracker deltaTracker) {
+		ArchitectManager.onDrawGameOverlay(graphics, deltaTracker);
+	}
+	*///?} else {
+	/*public static void renderHud(GuiGraphics graphics, float partialTicks) {
+		ArchitectManager.onDrawGameOverlay(graphics, partialTicks);
+	}
+	*///?}
 
 	/**
 	 * @return true when the mod consumed the scroll, so vanilla must not also act on it.

--- a/common/src/main/java/com/timmie/mightyarchitect/platform/MightyPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/platform/MightyPacket.java
@@ -1,0 +1,30 @@
+package com.timmie.mightyarchitect.platform;
+
+//? if >=1.20.2 {
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+//?} else {
+/*import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+*///?}
+
+/**
+ * The mod's own packet supertype, so the shared code has one name to talk about a packet regardless
+ * of what the game underneath calls one.
+ * <p>
+ * Vanilla gained {@code CustomPacketPayload} in 1.20.2, so from there this is simply that. Before
+ * it, custom packets were raw buffers on a named channel with no vanilla type at all, so this
+ * declares the identity and writer the loaders need. Either way the members below 1.20.5 are the
+ * same pair ({@code id()} + {@code write(FriendlyByteBuf)}), which is why every node older than
+ * 1.20.5 shares a single packet shape.
+ */
+//? if >=1.20.2 {
+public interface MightyPacket extends CustomPacketPayload {
+}
+//?} else {
+/*public interface MightyPacket {
+
+	ResourceLocation id();
+
+	void write(FriendlyByteBuf buffer);
+}
+*///?}

--- a/common/src/main/java/com/timmie/mightyarchitect/platform/PacketSender.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/platform/PacketSender.java
@@ -1,13 +1,11 @@
 package com.timmie.mightyarchitect.platform;
 
-import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-
 /**
  * Client-to-server delivery, supplied by the loader (Fabric's ClientPlayNetworking, NeoForge's
- * PacketDistributor).
+ * PacketDistributor, Forge's SimpleChannel).
  */
 @FunctionalInterface
 public interface PacketSender {
 
-	void sendToServer(CustomPacketPayload packet);
+	void sendToServer(MightyPacket packet);
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -131,9 +131,10 @@ tasks.named("runAutomatedServerTest") {
 }
 
 processResources {
-    // The blueprint post-process shader is driven from a mixin on Fabric; 1.21.1 predates the
-    // post_effect API that mixin targets, so that node ships no client mixins of its own.
-    def includeGameRendererMixin = stonecutter.current.version != "1.21.1"
+    // The blueprint post-process shader is driven from a mixin on Fabric; the post_effect API it
+    // targets only exists from 1.21.4, so every older node ships no client mixins of its own.
+    def postEffectVersions = ["1.21.4", "1.21.6", "1.21.8", "1.21.10", "1.21.11", "26.1"]
+    def includeGameRendererMixin = postEffectVersions.contains(stonecutter.current.version)
     def metaProps = [
         "version"            : project.version,
         "meta_mc_range"      : node.property('meta_mc_range'),
@@ -148,6 +149,17 @@ processResources {
     }
     filesMatching(["mightyarchitect.mixins.json", "mightyarchitect.fabric.mixins.json"]) {
         expand(metaProps + ["client_mixins": includeGameRendererMixin ? '["GameRendererMixin"]' : '[]'])
+    }
+}
+
+// The client-test and server-test companions share one unprocessed resource tree across every
+// node, so their mixin config follows this node's Java level rather than a hardcoded one.
+def testMetaProps = ["meta_java_range": node.property('meta_java_range')]
+
+tasks.named("processClientTestResources") {
+    inputs.properties(testMetaProps)
+    filesMatching("mightyarchitect-test.mixins.json") {
+        expand(testMetaProps)
     }
 }
 

--- a/fabric/src/main/java/com/timmie/mightyarchitect/fabric/TheMightyArchitectFabric.java
+++ b/fabric/src/main/java/com/timmie/mightyarchitect/fabric/TheMightyArchitectFabric.java
@@ -7,7 +7,12 @@ import com.timmie.mightyarchitect.networking.PlaceSignPacket;
 import com.timmie.mightyarchitect.networking.SetHotbarItemPacket;
 import com.timmie.mightyarchitect.platform.PacketContext;
 import net.fabricmc.api.ModInitializer;
+// PayloadTypeRegistry is the 1.20.5+ payload API; before that packets are raw buffers on a channel.
+//? if >=1.20.5 {
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+//?} else {
+/*
+*///?}
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -25,13 +30,11 @@ public class TheMightyArchitectFabric implements ModInitializer {
 		registerPackets();
 	}
 
+	// 26.1 renamed the Fabric API accessors to Mojang-style names along with the Yarn retirement,
+	// and 1.20.5 is where the payload registry replaced raw channel handlers altogether.
+	//? if >=26 {
 	private static void registerPackets() {
-		// 26.1 renamed the Fabric API accessors to Mojang-style names along with the Yarn retirement.
-		//? if >=26 {
 		PayloadTypeRegistry<net.minecraft.network.RegistryFriendlyByteBuf> c2s = PayloadTypeRegistry.serverboundPlay();
-		//?} else {
-		/*PayloadTypeRegistry<net.minecraft.network.RegistryFriendlyByteBuf> c2s = PayloadTypeRegistry.playC2S();
-		*///?}
 		c2s.register(AllPackets.INSTANT_PRINT_TYPE, AllPackets.INSTANT_PRINT_CODEC);
 		c2s.register(AllPackets.PLACE_SIGN_TYPE, AllPackets.PLACE_SIGN_CODEC);
 		c2s.register(AllPackets.SET_HOTBAR_ITEM_TYPE, AllPackets.SET_HOTBAR_ITEM_CODEC);
@@ -59,4 +62,67 @@ public class TheMightyArchitectFabric implements ModInitializer {
 			}
 		};
 	}
+	//?} else if >=1.20.5 {
+	/*private static void registerPackets() {
+		PayloadTypeRegistry<net.minecraft.network.RegistryFriendlyByteBuf> c2s = PayloadTypeRegistry.playC2S();
+		c2s.register(AllPackets.INSTANT_PRINT_TYPE, AllPackets.INSTANT_PRINT_CODEC);
+		c2s.register(AllPackets.PLACE_SIGN_TYPE, AllPackets.PLACE_SIGN_CODEC);
+		c2s.register(AllPackets.SET_HOTBAR_ITEM_TYPE, AllPackets.SET_HOTBAR_ITEM_CODEC);
+
+		ServerPlayNetworking.registerGlobalReceiver(AllPackets.INSTANT_PRINT_TYPE,
+			(payload, context) -> InstantPrintPacket.handle(payload, wrap(context)));
+		ServerPlayNetworking.registerGlobalReceiver(AllPackets.PLACE_SIGN_TYPE,
+			(payload, context) -> PlaceSignPacket.handle(payload, wrap(context)));
+		ServerPlayNetworking.registerGlobalReceiver(AllPackets.SET_HOTBAR_ITEM_TYPE,
+			(payload, context) -> SetHotbarItemPacket.handle(payload, wrap(context)));
+	}
+
+	private static PacketContext wrap(ServerPlayNetworking.Context context) {
+		return new PacketContext() {
+			@Override
+			public ServerPlayer player() {
+				return context.player();
+			}
+
+			@Override
+			public void enqueue(Runnable work) {
+				context.server().execute(work);
+			}
+		};
+	}
+	*///?} else {
+	/*// The raw buffer is only valid on the network thread, so each packet is decoded immediately
+	// and only the handling is deferred onto the server thread.
+	private static void registerPackets() {
+		ServerPlayNetworking.registerGlobalReceiver(AllPackets.INSTANT_PRINT_ID,
+			(server, player, handler, buf, responseSender) -> {
+				InstantPrintPacket packet = AllPackets.INSTANT_PRINT_DECODER.apply(buf);
+				InstantPrintPacket.handle(packet, wrap(server, player));
+			});
+		ServerPlayNetworking.registerGlobalReceiver(AllPackets.PLACE_SIGN_ID,
+			(server, player, handler, buf, responseSender) -> {
+				PlaceSignPacket packet = AllPackets.PLACE_SIGN_DECODER.apply(buf);
+				PlaceSignPacket.handle(packet, wrap(server, player));
+			});
+		ServerPlayNetworking.registerGlobalReceiver(AllPackets.SET_HOTBAR_ITEM_ID,
+			(server, player, handler, buf, responseSender) -> {
+				SetHotbarItemPacket packet = AllPackets.SET_HOTBAR_ITEM_DECODER.apply(buf);
+				SetHotbarItemPacket.handle(packet, wrap(server, player));
+			});
+	}
+
+	private static PacketContext wrap(net.minecraft.server.MinecraftServer server, ServerPlayer player) {
+		return new PacketContext() {
+			@Override
+			public ServerPlayer player() {
+				return player;
+			}
+
+			@Override
+			public void enqueue(Runnable work) {
+				server.execute(work);
+			}
+		};
+	}
+	*///?}
 }

--- a/fabric/src/main/java/com/timmie/mightyarchitect/fabric/TheMightyArchitectFabricClient.java
+++ b/fabric/src/main/java/com/timmie/mightyarchitect/fabric/TheMightyArchitectFabricClient.java
@@ -29,7 +29,18 @@ public class TheMightyArchitectFabricClient implements ClientModInitializer {
 		KeyBindingHelper.registerKeyBinding(MightyClient.TOOL_MENU);
 		*///?}
 
+		// Before 1.20.5 there is no payload type to send: packets go out as a raw buffer on a
+		// named channel, so the mod serialises them itself.
+		//? if >=1.20.5 {
 		AllPackets.setSender(ClientPlayNetworking::send);
+		//?} else {
+		/*AllPackets.setSender(packet -> {
+			net.minecraft.network.FriendlyByteBuf buffer =
+				net.fabricmc.fabric.api.networking.v1.PacketByteBufs.create();
+			packet.write(buffer);
+			ClientPlayNetworking.send(packet.id(), buffer);
+		});
+		*///?}
 
 		OnRenderWorld.RegisterRenderEvent();
 	}

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -1,0 +1,257 @@
+// Forge node (1.19.4, 1.20.1). NeoForge does not exist for 1.19.4, and NeoForge 1.20.1 is still
+// Forge-API compatible, so one Forge jar serves both loaders on these two versions.
+//
+// This is the same ModDevGradle the NeoForge node uses, plus its legacy addon: the mod is written
+// against official (Mojang) names and reobfuscated to SRG for production. See LEGACY.md upstream.
+def node = rootProject.project(":${stonecutter.current.version}")
+def javaVer = (node.findProperty('java_version') ?: '17') as int
+def mcVersion = node.property('minecraft_version')
+def forgeVersion = node.property('forge_version')
+def enableClientTestMod = project.findProperty("enableClientTestMod") == "true"
+def clientTestSessionId = System.getenv("MIGHTYARCHITECT_CLIENT_TEST_SESSION_ID")
+    ?.replaceAll("[^A-Za-z0-9._-]", "-")
+def clientTestRunDir = clientTestSessionId ? "run-client-test-${clientTestSessionId}" : "run-client-test"
+def clientTestResultFile = clientTestSessionId
+    ? layout.buildDirectory.file("client-test-${clientTestSessionId}/result.json")
+    : layout.buildDirectory.file("client-test/result.json")
+
+// Source inclusion: this node compiles the matching common node's Stonecutter output alongside its
+// own (see fabric/build.gradle for the full rationale).
+def commonNode = evaluationDependsOn(":common:${stonecutter.current.version}")
+def commonGenerate = commonNode.tasks.named("stonecutterGenerate")
+
+apply plugin: "java"
+apply plugin: "mightyarchitect.moddev-legacy"
+apply plugin: "maven-publish"
+
+base { archivesName = rootProject.archives_base_name }
+version = "${rootProject.mod_version}+mc${mcVersion}"
+group = rootProject.maven_group
+
+sourceSets {
+    main {
+        java.srcDirs commonNode.sourceSets.main.java.srcDirs
+        resources.srcDirs commonNode.sourceSets.main.resources.srcDirs
+    }
+    clientTest {
+        java.srcDirs = [
+            rootProject.file("client-test/src/main/java"),
+            rootProject.file("forge/src/clientTest/java")
+        ]
+        resources.srcDirs = [
+            rootProject.file("client-test/src/main/resources"),
+            rootProject.file("forge/src/clientTest/resources")
+        ]
+        output.resourcesDir = layout.buildDirectory.dir("classes/java/clientTest").get().asFile
+        compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+        runtimeClasspath += output + compileClasspath + sourceSets.main.runtimeClasspath
+    }
+    serverTest {
+        java.srcDirs = [
+            rootProject.file("server-test/src/main/java"),
+            rootProject.file("forge/src/serverTest/java")
+        ]
+        resources.srcDirs = [
+            rootProject.file("forge/src/serverTest/resources")
+        ]
+        output.resourcesDir = layout.buildDirectory.dir("classes/java/serverTest").get().asFile
+        compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
+        runtimeClasspath += output + compileClasspath + sourceSets.main.runtimeClasspath
+    }
+}
+
+// The generated common sources are task output, so the dependency has to be declared explicitly -
+// adding the directories to a source set does not carry one.
+tasks.named("compileJava") { dependsOn commonGenerate }
+tasks.named("processResources") { dependsOn commonGenerate }
+
+legacyForge {
+    version = forgeVersion
+
+    addModdingDependenciesTo sourceSets.clientTest
+    addModdingDependenciesTo sourceSets.serverTest
+
+    mods {
+        mightyarchitect {
+            sourceSet sourceSets.main
+        }
+        mightyarchitect_test {
+            sourceSet sourceSets.clientTest
+        }
+        mightyarchitect_server_test {
+            sourceSet sourceSets.serverTest
+        }
+    }
+
+    runs {
+        automatedClientTest {
+            client()
+            ideName = "Mighty Architect Automated Client Test"
+            gameDirectory = project.file(clientTestRunDir)
+            sourceSet = sourceSets.clientTest
+            loadedMods = enableClientTestMod
+                ? [mods.mightyarchitect, mods.mightyarchitect_test]
+                : [mods.mightyarchitect]
+            systemProperty "mightyarchitect.clientTest.enabled", "true"
+            systemProperty "mightyarchitect.clientTest.server",
+                (System.getenv("MIGHTYARCHITECT_CLIENT_TEST_SERVER")
+                    ?: project.findProperty("clientTestServer")
+                    ?: "127.0.0.1:25565").toString()
+            systemProperty "mightyarchitect.clientTest.result",
+                clientTestResultFile.get().asFile.absolutePath
+            systemProperty "mightyarchitect.clientTest.keepOpen",
+                (System.getenv("MIGHTYARCHITECT_CLIENT_TEST_KEEP_OPEN") ?: "false").toString()
+            // Mixin configs registered through the `mixin` extension are appended to *every* run's
+            // program arguments, so the companion mod's config is passed here instead - the server
+            // run has no client-test output on its classpath and dies initialising it.
+            if (enableClientTestMod) {
+                programArgument "--mixin.config"
+                programArgument "mightyarchitect-test.mixins.json"
+            }
+        }
+        automatedServerTest {
+            server()
+            ideName = "Mighty Architect Automated Server Test"
+            gameDirectory = project.file("run-server-test")
+            sourceSet = sourceSets.serverTest
+            loadedMods = [mods.mightyarchitect, mods.mightyarchitect_server_test]
+            systemProperty "mightyarchitect.serverTest.enabled", "true"
+        }
+    }
+}
+
+// Mixins are refmapped rather than remapped in place on this era, so the annotation processor has
+// to see every source set that carries a config.
+mixin {
+    add sourceSets.main, "mightyarchitect.refmap.json"
+    add sourceSets.clientTest, "mightyarchitect-test.refmap.json"
+    config "mightyarchitect.mixins.json"
+}
+
+// Every source set registered above contributes its generated .tsrg to one shared collection that
+// all reobfuscation tasks consume, and the path comes from the project layout rather than a task
+// output - so it carries no task dependency. Without this, a plain `build` reobfuscates the main
+// jar before the client-test refmap has ever been written and the run fails on a missing file.
+tasks.matching { it.name.startsWith("reobf") }.configureEach {
+    dependsOn tasks.named("compileClientTestJava")
+}
+
+configurations {
+    clientTestImplementation.extendsFrom implementation
+    clientTestRuntimeOnly.extendsFrom runtimeOnly
+    serverTestImplementation.extendsFrom implementation
+    serverTestRuntimeOnly.extendsFrom runtimeOnly
+}
+
+dependencies {
+    annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
+    clientTestAnnotationProcessor "org.spongepowered:mixin:0.8.5:processor"
+    clientTestImplementation sourceSets.main.output
+    serverTestImplementation sourceSets.main.output
+}
+
+tasks.named("runAutomatedClientTest") {
+    dependsOn tasks.named("clientTestClasses")
+}
+
+tasks.named("runAutomatedServerTest") {
+    dependsOn tasks.named("serverTestClasses")
+}
+
+processResources {
+    def metaProps = [
+        "version"          : project.version,
+        "meta_mc_range"    : node.property('meta_mc_range'),
+        "meta_mc_max"      : node.property('meta_mc_max'),
+        "meta_pack_format" : node.property('meta_pack_format'),
+        "meta_forge_range" : node.property('meta_forge_range'),
+        "meta_java_range"  : node.property('meta_java_range')
+    ]
+    inputs.properties(metaProps)
+    filesMatching("META-INF/mods.toml") {
+        expand(metaProps)
+    }
+    filesMatching("pack.mcmeta") {
+        expand(metaProps)
+    }
+    filesMatching("mightyarchitect.mixins.json") {
+        expand(metaProps)
+    }
+    // Fabric-only mixin config: harmless in the Forge jar, but leaving an unexpanded ${...}
+    // placeholder in a shipped file is not, so drop it here.
+    exclude "mightyarchitect.fabric.mixins.json"
+}
+
+// The test companions share one unprocessed resource tree across every node, so their mixin
+// config and mod metadata follow this node's Java level and Forge loader major.
+def testMetaProps = [
+    "meta_java_range" : node.property('meta_java_range'),
+    "meta_forge_range": node.property('meta_forge_range')
+]
+
+tasks.named("processClientTestResources") {
+    inputs.properties(testMetaProps)
+    filesMatching("mightyarchitect-test.mixins.json") {
+        expand(testMetaProps)
+    }
+    filesMatching("META-INF/mods.toml") {
+        expand(testMetaProps)
+    }
+}
+
+tasks.named("processServerTestResources") {
+    inputs.properties(testMetaProps)
+    filesMatching("META-INF/mods.toml") {
+        expand(testMetaProps)
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = "UTF-8"
+    options.release = javaVer
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(javaVer)
+    }
+}
+
+// FML on this era discovers mixin configs from the jar manifest, not from mods.toml.
+jar {
+    manifest.attributes(["MixinConfigs": "mightyarchitect.mixins.json"])
+    archiveClassifier.set("forge")
+}
+
+def clientTestJarTask = tasks.register("clientTestJar", Jar) {
+    dependsOn tasks.named("clientTestClasses")
+    from sourceSets.clientTest.output
+    manifest.attributes(["MixinConfigs": "mightyarchitect-test.mixins.json"])
+    archiveClassifier.set("forge-client-test-dev")
+}
+
+// The companion mod is also written against official names, so it needs the same SRG pass the
+// main jar gets before a production client will load it. Reobfuscation is driven off the main
+// source set's classpath (as upstream's shadowJar example does) because that is what carries the
+// inherited Minecraft members; clientTest has no consumable runtime elements of its own.
+obfuscation {
+    reobfuscate(clientTestJarTask, sourceSets.main) {
+        archiveClassifier.set("forge-client-test")
+    }
+}
+
+tasks.register("buildClientTestMod") {
+    group = "verification"
+    description = "Builds the distributable Forge client-test companion mod."
+    dependsOn clientTestJarTask
+}
+
+publishing {
+    publications {
+        mavenForge(MavenPublication) {
+            artifactId = rootProject.archives_base_name + "-forge"
+            from components.java
+        }
+    }
+    repositories {}
+}

--- a/forge/src/clientTest/java/com/timmie/mightyarchitect/test/forge/MightyArchitectClientTestForge.java
+++ b/forge/src/clientTest/java/com/timmie/mightyarchitect/test/forge/MightyArchitectClientTestForge.java
@@ -1,0 +1,15 @@
+package com.timmie.mightyarchitect.test.forge;
+
+import com.timmie.mightyarchitect.test.ClientTestController;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLEnvironment;
+
+@Mod("mightyarchitect_test")
+public class MightyArchitectClientTestForge {
+
+    public MightyArchitectClientTestForge() {
+        if (FMLEnvironment.dist == Dist.CLIENT)
+            ClientTestController.start();
+    }
+}

--- a/forge/src/clientTest/resources/META-INF/mods.toml
+++ b/forge/src/clientTest/resources/META-INF/mods.toml
@@ -1,0 +1,19 @@
+modLoader = "javafml"
+loaderVersion = "[${meta_forge_range},)"
+license = "MIT"
+
+[[mods]]
+modId = "mightyarchitect_test"
+version = "1.0.0"
+displayName = "The Mighty Architect Client Test"
+description = "Automated client integration-test companion."
+
+[[mixins]]
+config = "mightyarchitect-test.mixins.json"
+
+[[dependencies.mightyarchitect_test]]
+modId = "mightyarchitect"
+mandatory = true
+versionRange = "[0,)"
+ordering = "AFTER"
+side = "CLIENT"

--- a/forge/src/main/java/com/timmie/mightyarchitect/forge/OnRenderWorld.java
+++ b/forge/src/main/java/com/timmie/mightyarchitect/forge/OnRenderWorld.java
@@ -1,0 +1,37 @@
+package com.timmie.mightyarchitect.forge;
+
+import com.timmie.mightyarchitect.MightyClient;
+import com.timmie.mightyarchitect.platform.ClientHooks;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RenderGuiEvent;
+import net.minecraftforge.client.event.RenderLevelStageEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(value = Dist.CLIENT)
+public class OnRenderWorld {
+
+    // AFTER_PARTICLES keeps the level's translucent pass active, so translucent overlays and
+    // world-space text glyphs still composite into the frame (see the NeoForge branch for the
+    // full rationale).
+    @SubscribeEvent
+    public static void onRenderWorld(RenderLevelStageEvent event) {
+        if (event.getStage() == RenderLevelStageEvent.Stage.AFTER_PARTICLES) {
+            MightyClient.onRenderWorld(event.getPoseStack());
+        }
+    }
+
+    // ForgeGui replaces the vanilla Gui instance and overrides render() without calling super, so
+    // the shared GuiMixin never fires on this loader. This event is what ForgeGui posts at the end
+    // of that override, which is the same point the mixin targets.
+    @SubscribeEvent
+    public static void onRenderHud(RenderGuiEvent.Post event) {
+        //? if >=1.20 {
+        ClientHooks.renderHud(event.getGuiGraphics(), event.getPartialTick());
+        //?} else {
+        /*ClientHooks.renderHud(
+            new com.timmie.mightyarchitect.foundation.gui.GuiGraphics(event.getPoseStack()),
+            event.getPartialTick());
+        *///?}
+    }
+}

--- a/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForge.java
+++ b/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForge.java
@@ -1,0 +1,99 @@
+package com.timmie.mightyarchitect.forge;
+
+import com.timmie.mightyarchitect.AllPackets;
+import com.timmie.mightyarchitect.TheMightyArchitect;
+import com.timmie.mightyarchitect.networking.InstantPrintPacket;
+import com.timmie.mightyarchitect.networking.PlaceSignPacket;
+import com.timmie.mightyarchitect.networking.SetHotbarItemPacket;
+import com.timmie.mightyarchitect.platform.MightyPacket;
+import com.timmie.mightyarchitect.platform.PacketContext;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.eventbus.api.IEventBus;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.network.NetworkRegistry;
+import net.minecraftforge.network.simple.SimpleChannel;
+import net.minecraftforge.registries.DeferredRegister;
+
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+/**
+ * Forge entrypoint for 1.19.4 and 1.20.1.
+ * <p>
+ * This era predates vanilla's custom payloads, so packets travel as raw buffers on a
+ * {@link SimpleChannel}. The shared code still describes a packet the same way - an id plus a
+ * writer - so only the wiring here differs from the NeoForge node.
+ */
+@Mod(TheMightyArchitectForge.ID)
+public class TheMightyArchitectForge {
+
+	public static final String ID = "mightyarchitect";
+
+	// Forge requires a channel to declare a protocol version and accept/reject predicates. These
+	// packets are a client-side convenience, so both ends accept anything: a vanilla or mod-less
+	// server simply never receives them, which is the same effect as NeoForge's optional().
+	private static final String PROTOCOL = "1";
+	private static final SimpleChannel CHANNEL = NetworkRegistry.newSimpleChannel(
+		TheMightyArchitect.id("main"), () -> PROTOCOL, ignored -> true, ignored -> true);
+
+	private static final DeferredRegister<Block> BLOCKS = DeferredRegister.create(Registries.BLOCK, ID);
+	private static final DeferredRegister<Item> ITEMS = DeferredRegister.create(Registries.ITEM, ID);
+
+	public TheMightyArchitectForge() {
+		IEventBus modEventBus = FMLJavaModLoadingContext.get()
+			.getModEventBus();
+
+		// DeferredRegister.register returns a RegistryObject; the shared registrar contract is
+		// void, so the handle is simply discarded - the mod reads its blocks back through
+		// AllBlocks, which the factories populate when Forge runs them.
+		TheMightyArchitect.Init(
+			(name, factory) -> BLOCKS.register(name, factory::get),
+			(name, factory) -> ITEMS.register(name, factory::get));
+		BLOCKS.register(modEventBus);
+		ITEMS.register(modEventBus);
+
+		registerPackets();
+	}
+
+	private static void registerPackets() {
+		int index = 0;
+		register(index++, InstantPrintPacket.class, AllPackets.INSTANT_PRINT_DECODER,
+			InstantPrintPacket::handle);
+		register(index++, PlaceSignPacket.class, AllPackets.PLACE_SIGN_DECODER,
+			PlaceSignPacket::handle);
+		register(index++, SetHotbarItemPacket.class, AllPackets.SET_HOTBAR_ITEM_DECODER,
+			SetHotbarItemPacket::handle);
+
+		AllPackets.setSender(CHANNEL::sendToServer);
+	}
+
+	private static <T extends MightyPacket> void register(int index, Class<T> type,
+		Function<FriendlyByteBuf, T> decoder, BiConsumer<T, PacketContext> handler) {
+		CHANNEL.registerMessage(index, type, (packet, buffer) -> packet.write(buffer), decoder,
+			(packet, context) -> {
+				NetworkEvent.Context ctx = context.get();
+				handler.accept(packet, wrap(ctx));
+				ctx.setPacketHandled(true);
+			});
+	}
+
+	private static PacketContext wrap(NetworkEvent.Context context) {
+		return new PacketContext() {
+			@Override
+			public ServerPlayer player() {
+				return context.getSender();
+			}
+
+			@Override
+			public void enqueue(Runnable work) {
+				context.enqueueWork(work);
+			}
+		};
+	}
+}

--- a/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
+++ b/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
@@ -1,0 +1,27 @@
+package com.timmie.mightyarchitect.forge;
+
+import com.timmie.mightyarchitect.MightyClient;
+import com.timmie.mightyarchitect.platform.Env;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+/**
+ * Client-side setup for the Forge nodes. This era has no {@code dist} attribute on {@code @Mod}, so
+ * the side is expressed with an event-bus subscriber restricted to {@link Dist#CLIENT} instead.
+ */
+@Mod.EventBusSubscriber(value = Dist.CLIENT, bus = Mod.EventBusSubscriber.Bus.MOD)
+public class TheMightyArchitectForgeClient {
+
+	@SubscribeEvent
+	public static void registerKeyMappings(RegisterKeyMappingsEvent event) {
+		// Reaching this listener at all proves the physical client, and key mappings have to exist
+		// before Options is built - which is exactly when Forge fires this event.
+		Env.setClient(true);
+		MightyClient.init();
+
+		event.register(MightyClient.COMPOSE);
+		event.register(MightyClient.TOOL_MENU);
+	}
+}

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,31 @@
+modLoader = "javafml"
+loaderVersion = "[${meta_forge_range},)"
+issueTrackerURL = "https://github.com/TimStewartJ/TheMightyArchitectury/issues"
+license = "MIT"
+
+[[mods]]
+modId = "mightyarchitect"
+version = "${version}"
+displayName = "The Mighty Architect"
+authors = "simibubi, timmie"
+description = '''
+Design elaborate buildings within a minute!
+'''
+#logoFile = ""
+
+[[mixins]]
+config = "mightyarchitect.mixins.json"
+
+[[dependencies.mightyarchitect]]
+modId = "forge"
+mandatory = true
+versionRange = "[${meta_forge_range},)"
+ordering = "NONE"
+side = "BOTH"
+
+[[dependencies.mightyarchitect]]
+modId = "minecraft"
+mandatory = true
+versionRange = "[${meta_mc_range},${meta_mc_max})"
+ordering = "NONE"
+side = "BOTH"

--- a/forge/src/main/resources/pack.mcmeta
+++ b/forge/src/main/resources/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "description": "Mighty Architectury",
+    "pack_format": ${meta_pack_format}
+  }
+}

--- a/forge/src/serverTest/java/com/timmie/mightyarchitect/test/server/forge/MightyArchitectServerTestForge.java
+++ b/forge/src/serverTest/java/com/timmie/mightyarchitect/test/server/forge/MightyArchitectServerTestForge.java
@@ -1,0 +1,21 @@
+package com.timmie.mightyarchitect.test.server.forge;
+
+import com.timmie.mightyarchitect.test.server.ServerPrintTest;
+import net.minecraftforge.common.MinecraftForge;
+import net.minecraftforge.event.server.ServerStartedEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod(MightyArchitectServerTestForge.ID)
+public class MightyArchitectServerTestForge {
+
+	public static final String ID = "mightyarchitect_server_test";
+
+	public MightyArchitectServerTestForge() {
+		// ServerStartedEvent rather than mod construction: the test needs a loaded overworld.
+		MinecraftForge.EVENT_BUS.addListener(MightyArchitectServerTestForge::onServerStarted);
+	}
+
+	private static void onServerStarted(ServerStartedEvent event) {
+		ServerPrintTest.run(event.getServer());
+	}
+}

--- a/forge/src/serverTest/resources/META-INF/mods.toml
+++ b/forge/src/serverTest/resources/META-INF/mods.toml
@@ -1,0 +1,16 @@
+modLoader = "javafml"
+loaderVersion = "[${meta_forge_range},)"
+license = "MIT"
+
+[[mods]]
+modId = "mightyarchitect_server_test"
+version = "1.0.0"
+displayName = "The Mighty Architect Server Test"
+description = "Automated server integration-test companion."
+
+[[dependencies.mightyarchitect_server_test]]
+modId = "mightyarchitect"
+mandatory = true
+versionRange = "[0,)"
+ordering = "AFTER"
+side = "BOTH"

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -3,6 +3,11 @@ def javaVer = (node.findProperty('java_version') ?: '21') as int
 def mcVersion = node.property('minecraft_version')
 def neoforgeVersion = node.property('neoforge_version')
 def enableClientTestMod = project.findProperty("enableClientTestMod") == "true"
+// NeoForge only started reading META-INF/neoforge.mods.toml in 20.5/1.20.5. Older nodes get the
+// same template renamed back to the Forge-era path. (20.4 does already accept `type` dependency
+// entries, so only the file name differs.)
+def legacyModsToml = stonecutter.eval(stonecutter.current.version, "<1.20.5")
+final String LEGACY_METADATA_PATH = "META-INF/mods.toml"
 def clientTestSessionId = System.getenv("MIGHTYARCHITECT_CLIENT_TEST_SESSION_ID")
     ?.replaceAll("[^A-Za-z0-9._-]", "-")
 def clientTestRunDir = clientTestSessionId ? "run-client-test-${clientTestSessionId}" : "run-client-test"
@@ -139,8 +144,12 @@ processResources {
         "meta_fml_range"      : (node.findProperty('meta_fml_range') ?: '3')
     ]
     inputs.properties(metaProps)
+    inputs.property("legacy_mods_toml", legacyModsToml)
     filesMatching("META-INF/neoforge.mods.toml") {
         expand(metaProps)
+        if (legacyModsToml) {
+            it.path = LEGACY_METADATA_PATH
+        }
     }
     filesMatching("pack.mcmeta") {
         expand(metaProps)
@@ -151,6 +160,38 @@ processResources {
     // Fabric-only mixin config: harmless in the NeoForge jar, but leaving an unexpanded
     // ${...} placeholder in a shipped file is not, so drop it here.
     exclude "mightyarchitect.fabric.mixins.json"
+}
+
+// The test companions share one unprocessed resource tree across every node, so their mixin
+// config and mod metadata follow this node's Java level and FML loader major.
+def testMetaProps = [
+    "meta_java_range": node.property('meta_java_range'),
+    "meta_fml_range" : (node.findProperty('meta_fml_range') ?: '3')
+]
+
+tasks.named("processClientTestResources") {
+    inputs.properties(testMetaProps)
+    inputs.property("legacy_mods_toml", legacyModsToml)
+    filesMatching("mightyarchitect-test.mixins.json") {
+        expand(testMetaProps)
+    }
+    filesMatching("META-INF/neoforge.mods.toml") {
+        expand(testMetaProps)
+        if (legacyModsToml) {
+            it.path = LEGACY_METADATA_PATH
+        }
+    }
+}
+
+tasks.named("processServerTestResources") {
+    inputs.properties(testMetaProps)
+    inputs.property("legacy_mods_toml", legacyModsToml)
+    filesMatching("META-INF/neoforge.mods.toml") {
+        expand(testMetaProps)
+        if (legacyModsToml) {
+            it.path = LEGACY_METADATA_PATH
+        }
+    }
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/neoforge/src/clientTest/java/com/timmie/mightyarchitect/test/neoforge/MightyArchitectClientTestNeoForge.java
+++ b/neoforge/src/clientTest/java/com/timmie/mightyarchitect/test/neoforge/MightyArchitectClientTestNeoForge.java
@@ -4,7 +4,9 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.loading.FMLEnvironment;
 
-@Mod(value = "mightyarchitect_test", dist = Dist.CLIENT)
+// The @Mod `dist` attribute only exists from NeoForge 20.6 onward, and this source set is shared
+// verbatim by every node, so the client-only guard is the runtime check in the constructor.
+@Mod("mightyarchitect_test")
 public class MightyArchitectClientTestNeoForge {
 
     public MightyArchitectClientTestNeoForge() {

--- a/neoforge/src/clientTest/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/clientTest/resources/META-INF/neoforge.mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[3,)"
+loaderVersion = "[${meta_fml_range},)"
 license = "MIT"
 
 [[mods]]

--- a/neoforge/src/main/java/com/timmie/mightyarchitect/forge/OnRenderWorld.java
+++ b/neoforge/src/main/java/com/timmie/mightyarchitect/forge/OnRenderWorld.java
@@ -8,7 +8,11 @@ import net.minecraft.client.Minecraft;
 *///?}
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
+//? if >=1.20.5 {
 import net.neoforged.fml.common.EventBusSubscriber;
+//?} else {
+/*import net.neoforged.fml.common.Mod.EventBusSubscriber;
+*///?}
 //? if >=26.2 {
 /*import net.neoforged.neoforge.client.event.SubmitCustomGeometryEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent.AfterLevel;
@@ -79,5 +83,17 @@ public class OnRenderWorld {
     }
     //?} else {
     /*
+    *///?}
+
+    // NeoForge 20.4 still ships ExtendedGui, which replaces the vanilla Gui instance and overrides
+    // render() without calling super - so the shared GuiMixin never fires there and the HUD has to
+    // come off Forge's own overlay event. 20.5 dropped ExtendedGui for layered rendering on
+    // vanilla's Gui, where the mixin works, so this arm is empty from then on.
+    //? if <1.20.5 {
+    /*@SubscribeEvent
+    public static void onRenderHud(net.neoforged.neoforge.client.event.RenderGuiEvent.Post event) {
+        com.timmie.mightyarchitect.platform.ClientHooks.renderHud(event.getGuiGraphics(),
+            event.getPartialTick());
+    }
     *///?}
 }

--- a/neoforge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForge.java
+++ b/neoforge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForge.java
@@ -12,9 +12,17 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
+// NeoForge reworked payload registration in 20.5: the event, the registrar and the registration
+// method were all renamed, and codecs replaced plain buffer readers.
+//? if >=1.20.5 {
 import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
 import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+//?} else {
+/*import net.neoforged.neoforge.network.event.RegisterPayloadHandlerEvent;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import net.neoforged.neoforge.network.registration.IPayloadRegistrar;
+*///?}
 import net.neoforged.neoforge.registries.DeferredRegister;
 
 @Mod(TheMightyArchitectForge.ID)
@@ -34,11 +42,20 @@ public class TheMightyArchitectForge {
 		ITEMS.register(modEventBus);
 
 		modEventBus.addListener(TheMightyArchitectForge::registerPackets);
+
+		// 20.4's @Mod cannot declare a dist, so the client half is started from here. The class is
+		// only touched inside this branch, so a dedicated server never loads it.
+		//? if >=1.20.5 {
+		//?} else {
+		/*if (net.neoforged.fml.loading.FMLEnvironment.dist == net.neoforged.api.distmarker.Dist.CLIENT)
+			TheMightyArchitectForgeClient.init(modEventBus);
+		*///?}
 	}
 
+	// Optional in both eras: these are client-to-server conveniences, and marking them required
+	// would stop NeoForge clients from joining vanilla (or otherwise mod-less) servers at all.
+	//? if >=1.20.5 {
 	private static void registerPackets(RegisterPayloadHandlersEvent event) {
-		// Optional: these are client-to-server conveniences, and marking them required would stop
-		// NeoForge clients from joining vanilla (or otherwise mod-less) servers at all.
 		PayloadRegistrar registrar = event.registrar("1")
 			.optional();
 		registrar.playToServer(AllPackets.INSTANT_PRINT_TYPE, AllPackets.INSTANT_PRINT_CODEC,
@@ -48,7 +65,23 @@ public class TheMightyArchitectForge {
 		registrar.playToServer(AllPackets.SET_HOTBAR_ITEM_TYPE, AllPackets.SET_HOTBAR_ITEM_CODEC,
 			(payload, context) -> SetHotbarItemPacket.handle(payload, wrap(context)));
 	}
+	//?} else {
+	/*private static void registerPackets(RegisterPayloadHandlerEvent event) {
+		// 20.4 takes the *namespace* here and carries the protocol version separately; 20.5
+		// swapped the argument for the version and derives the namespace from the mod container.
+		IPayloadRegistrar registrar = event.registrar(ID)
+			.versioned("1")
+			.optional();
+		registrar.play(AllPackets.INSTANT_PRINT_ID, AllPackets.INSTANT_PRINT_DECODER::apply,
+			(payload, context) -> InstantPrintPacket.handle(payload, wrap(context)));
+		registrar.play(AllPackets.PLACE_SIGN_ID, AllPackets.PLACE_SIGN_DECODER::apply,
+			(payload, context) -> PlaceSignPacket.handle(payload, wrap(context)));
+		registrar.play(AllPackets.SET_HOTBAR_ITEM_ID, AllPackets.SET_HOTBAR_ITEM_DECODER::apply,
+			(payload, context) -> SetHotbarItemPacket.handle(payload, wrap(context)));
+	}
+	*///?}
 
+	//? if >=1.20.5 {
 	private static PacketContext wrap(IPayloadContext context) {
 		return new PacketContext() {
 			@Override
@@ -62,4 +95,21 @@ public class TheMightyArchitectForge {
 			}
 		};
 	}
+	//?} else {
+	/*// Before 1.20.5 the context exposes an Optional player and a separate work handler.
+	private static PacketContext wrap(IPayloadContext context) {
+		return new PacketContext() {
+			@Override
+			public ServerPlayer player() {
+				return (ServerPlayer) context.player()
+					.orElseThrow(() -> new IllegalStateException("Serverbound payload without a player"));
+			}
+
+			@Override
+			public void enqueue(Runnable work) {
+				context.workHandler().execute(work);
+			}
+		};
+	}
+	*///?}
 }

--- a/neoforge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
+++ b/neoforge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
@@ -13,22 +13,34 @@ import net.neoforged.neoforge.client.network.ClientPacketDistributor;
 *///?}
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
 
-// Constructed by FML only on the physical client, which is also how the mod learns its side
-// without reaching into loader internals.
+// From 20.5 FML constructs this only on the physical client, which is also how the mod learns its
+// side without reaching into loader internals. 20.4's @Mod has no dist attribute, so there the main
+// entrypoint calls init() behind its own side check instead.
+//? if >=1.20.5 {
 @Mod(value = TheMightyArchitectForge.ID, dist = Dist.CLIENT)
 public class TheMightyArchitectForgeClient {
 
 	public TheMightyArchitectForgeClient(IEventBus modEventBus) {
+//?} else {
+/*public class TheMightyArchitectForgeClient {
+
+	public static void init(IEventBus modEventBus) {
+*///?}
 		Env.setClient(true);
 
 		// Key mappings have to exist before RegisterKeyMappingsEvent, which NeoForge fires while
 		// Options is being built - so build them here rather than in a setup listener.
 		MightyClient.init();
 
+		// The client-side distributor moved to its own class in 21.8, and before 1.20.5 there is no
+		// payload-level send at all - the payload has to be wrapped in the vanilla packet first.
 		//? if >=1.21.8 {
 		AllPackets.setSender(ClientPacketDistributor::sendToServer);
-		//?} else {
+		//?} else if >=1.20.5 {
 		/*AllPackets.setSender(PacketDistributor::sendToServer);
+		*///?} else {
+		/*AllPackets.setSender(packet -> PacketDistributor.SERVER.noArg()
+			.send(new net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket(packet)));
 		*///?}
 
 		modEventBus.addListener(TheMightyArchitectForgeClient::registerKeyMappings);

--- a/neoforge/src/serverTest/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/serverTest/resources/META-INF/neoforge.mods.toml
@@ -1,5 +1,5 @@
 modLoader = "javafml"
-loaderVersion = "[3,)"
+loaderVersion = "[${meta_fml_range},)"
 license = "MIT"
 
 [[mods]]

--- a/scripts/TestMatrix.Common.psm1
+++ b/scripts/TestMatrix.Common.psm1
@@ -383,6 +383,43 @@ function Expand-TestListArgument {
     return $expanded
 }
 
+function Get-TestVersionLoaders {
+    <#
+        Returns the loaders a Minecraft version actually ships, mirroring the branch scoping in
+        settings.gradle. NeoForge does not exist before 1.20.2 and cannot be built at all for
+        1.20.2/1.20.3 (no build in those lines publishes the Gradle module metadata ModDevGradle
+        resolves through), so 1.19.4 and 1.20.1 ship Forge instead and 1.20.2 is Fabric-only.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version
+    )
+
+    if ($Version -in @('1.19.4', '1.20.1')) {
+        return @('fabric', 'forge')
+    }
+    if ($Version -eq '1.20.2') {
+        return @('fabric')
+    }
+    return @('fabric', 'neoforge')
+}
+
+function Select-TestVersionLoaders {
+    <#
+        Intersects the requested loaders with the ones this version actually ships, keeping the
+        caller's ability to narrow the matrix with -Loaders without inventing missing targets.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Version,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$Requested
+    )
+
+    return @(Get-TestVersionLoaders -Version $Version | Where-Object { $_ -in $Requested })
+}
+
 function Find-TestGradleArtifact {
     param(
         [Parameter(Mandatory = $true)]
@@ -465,7 +502,7 @@ function Test-RuntimeArtifactStale {
     }
 
     foreach ($version in $Versions) {
-        foreach ($loader in $Loaders) {
+        foreach ($loader in (Select-TestVersionLoaders -Version $version -Requested $Loaders)) {
             $target = Get-RuntimeArtifactTarget -Manifest $manifest -Version $version -Loader $loader
             if (-not $target) {
                 return "missing target $version/$loader"
@@ -487,7 +524,7 @@ function Test-RuntimeArtifactStale {
             [Globalization.DateTimeStyles]::RoundtripKind
         ).ToUniversalTime()
     }
-    $sourceRoots = @('common/src', 'fabric/src', 'neoforge/src', 'client-test/src') |
+    $sourceRoots = @('common/src', 'fabric/src', 'neoforge/src', 'forge/src', 'client-test/src') |
         ForEach-Object { Join-Path $RepoRoot $_ } |
         Where-Object { Test-Path $_ }
     $sourceRoots += @(Join-Path $RepoRoot 'buildSrc') | Where-Object { Test-Path $_ }
@@ -501,7 +538,7 @@ function Test-RuntimeArtifactStale {
     }
 
     $buildInputs = @('build.gradle', 'settings.gradle', 'stonecutter.gradle', 'gradle.properties',
-        'common/build.gradle', 'fabric/build.gradle', 'neoforge/build.gradle')
+        'common/build.gradle', 'fabric/build.gradle', 'neoforge/build.gradle', 'forge/build.gradle')
     foreach ($version in $Versions) {
         $buildInputs += "versions/$version/gradle.properties"
     }
@@ -544,6 +581,9 @@ function Test-TestRetryableFailure {
         'Read timed out',
         'Connection reset',
         'Connection timed out',
+        # Loom's asset downloader losing its own thread pool mid-run, seen as
+        # `:downloadAssets` failing with a RejectedExecutionException.
+        'rejected from java\.util\.concurrent\.ThreadPoolExecutor',
         'HashMap\$Node cannot be cast to class java\.util\.HashMap\$TreeNode'
     )
 
@@ -573,6 +613,8 @@ Export-ModuleMember -Function @(
     'Get-TestHiddenWindowOption',
     'Write-TestClientOptions',
     'Expand-TestListArgument',
+    'Get-TestVersionLoaders',
+    'Select-TestVersionLoaders',
     'Find-TestGradleArtifact',
     'Get-RuntimeArtifactManifestPath',
     'Read-RuntimeArtifactManifest',

--- a/scripts/prepare-runtime-artifacts.ps1
+++ b/scripts/prepare-runtime-artifacts.ps1
@@ -1,6 +1,6 @@
 param(
-    [string[]]$Versions = @('1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
-    [string[]]$Loaders = @('fabric', 'neoforge')
+    [string[]]$Versions = @('1.19.4', '1.20.1', '1.20.2', '1.20.4', '1.20.6', '1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
+    [string[]]$Loaders = @('fabric', 'neoforge', 'forge')
 )
 
 $ErrorActionPreference = 'Stop'
@@ -10,7 +10,7 @@ Import-Module (Join-Path $PSScriptRoot 'TestMatrix.Common.psm1') -Force
 Assert-TestMatrixPowerShell
 
 $Versions = Expand-TestListArgument -Value $Versions
-$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge')
+$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge', 'forge')
 
 $RepoRoot = Get-TestMatrixRepoRoot -ScriptRoot $PSScriptRoot
 $Gradle = Get-TestGradleCommand -RepoRoot $RepoRoot
@@ -48,15 +48,17 @@ function Get-ClientTestJar {
 }
 
 $tasks = [System.Collections.Generic.List[string]]::new()
+$targetCount = 0
 foreach ($version in $Versions) {
-    foreach ($loader in $Loaders) {
+    foreach ($loader in (Select-TestVersionLoaders -Version $version -Requested $Loaders)) {
+        $targetCount++
         $tasks.Add(":${loader}:${version}:build")
         $tasks.Add(":${loader}:${version}:buildClientTestMod")
     }
 }
 
-Write-Host "Preparing runtime artifacts for $($Versions.Count * $Loaders.Count) target(s)"
-$arguments = $tasks + @('--console=plain', '-Porg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64,JAVA_HOME_25_X64')
+Write-Host "Preparing runtime artifacts for $targetCount target(s)"
+$arguments = $tasks + @('--console=plain', '-Porg.gradle.java.installations.fromEnv=JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64')
 & $Gradle @arguments
 if ($LASTEXITCODE -ne 0) {
     throw "Gradle artifact preparation failed with exit code $LASTEXITCODE"
@@ -65,7 +67,7 @@ if ($LASTEXITCODE -ne 0) {
 $targets = [System.Collections.Generic.List[object]]::new()
 foreach ($version in $Versions) {
     $properties = Get-TestNodeProperties -RepoRoot $RepoRoot -Version $version
-    foreach ($loader in $Loaders) {
+    foreach ($loader in (Select-TestVersionLoaders -Version $version -Requested $Loaders)) {
         $modJar = Get-ProductionJar -Version $version -Loader $loader
         $testJar = Get-ClientTestJar -Version $version -Loader $loader
 

--- a/scripts/run-client-test-matrix.ps1
+++ b/scripts/run-client-test-matrix.ps1
@@ -1,6 +1,6 @@
 param(
-    [string[]]$Versions = @('1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
-    [string[]]$Loaders = @('fabric', 'neoforge'),
+    [string[]]$Versions = @('1.19.4', '1.20.1', '1.20.2', '1.20.4', '1.20.6', '1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
+    [string[]]$Loaders = @('fabric', 'neoforge', 'forge'),
     [int]$Port = 25565,
     [int]$ClientTimeoutSeconds = 600,
     [switch]$KeepOpen
@@ -13,7 +13,7 @@ Import-Module (Join-Path $PSScriptRoot 'TestMatrix.Common.psm1') -Force
 Assert-TestMatrixPowerShell
 
 $Versions = Expand-TestListArgument -Value $Versions
-$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge')
+$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge', 'forge')
 
 $RepoRoot = Get-TestMatrixRepoRoot -ScriptRoot $PSScriptRoot
 $BuildRoot = Join-Path $RepoRoot 'build'
@@ -21,7 +21,7 @@ $RuntimeRoot = Join-Path $BuildRoot 'client-test-runtime'
 $ResultsRoot = Join-Path $BuildRoot 'client-test-results'
 $Gradle = Get-TestGradleCommand -RepoRoot $RepoRoot
 
-if ($KeepOpen -and ($Versions.Count -ne 1 -or $Loaders.Count -ne 1)) {
+if ($KeepOpen -and ($Versions.Count -ne 1 -or (Select-TestVersionLoaders -Version $Versions[0] -Requested $Loaders).Count -ne 1)) {
     throw '-KeepOpen requires exactly one version and one loader. Start multiple invocations with distinct -Port values for simultaneous clients.'
 }
 
@@ -103,10 +103,12 @@ function Invoke-ClientTest {
         $gradleArguments.Add(":${Loader}:${Version}:runAutomatedClientTest")
         $gradleArguments.Add('--console=plain')
         $gradleArguments.Add('--no-daemon')
-        if ($Loader -eq 'neoforge') {
+        # Fabric runs the companion from its own source set; the Forge-family loaders load it as a
+        # local runtime mod jar instead.
+        if ($Loader -eq 'neoforge' -or $Loader -eq 'forge') {
             $gradleArguments.Add('-PenableClientTestMod=true')
         }
-        $gradleArguments.Add('-Porg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64,JAVA_HOME_25_X64')
+        $gradleArguments.Add('-Porg.gradle.java.installations.fromEnv=JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64')
         $hiddenWindow = Get-TestHiddenWindowOption
         $gradleProcess = Start-Process -FilePath $Gradle `
             -ArgumentList $gradleArguments `
@@ -165,13 +167,14 @@ function Invoke-ClientTest {
                 if ($shutdownWatchdog -and $resultPassed) {
                     Write-Host "WARN $Version / $Loader - checks passed; client missed the 15s shutdown deadline and vanilla force-exited it ($gradleExit)" -ForegroundColor Yellow
                 } else {
-                    if (Test-Path $gradleStdout) {
-                        Get-Content $gradleStdout -Tail 30 | ForEach-Object { Write-Host $_ }
-                    }
-                    if (Test-Path $gradleStderr) {
-                        Get-Content $gradleStderr -Tail 30 | ForEach-Object { Write-Host $_ -ForegroundColor Red }
-                    }
-                    throw "Gradle client test exited $gradleExit"
+                    $stdoutTail = if (Test-Path $gradleStdout) { (Get-Content $gradleStdout -Tail 30) -join "`n" } else { '' }
+                    $stderrTail = if (Test-Path $gradleStderr) { (Get-Content $gradleStderr -Tail 30) -join "`n" } else { '' }
+                    if ($stdoutTail) { Write-Host $stdoutTail }
+                    if ($stderrTail) { Write-Host $stderrTail -ForegroundColor Red }
+                    # The tail travels in the message so infrastructure failures inside Gradle itself
+                    # (asset downloads and the like) can be classified as retryable, the way the
+                    # server matrix already does.
+                    throw "Gradle client test exited $gradleExit`n$stdoutTail`n$stderrTail"
                 }
             }
         }
@@ -227,16 +230,18 @@ New-Item -ItemType Directory -Force -Path $RuntimeRoot, $ResultsRoot | Out-Null
 $failures = [System.Collections.Generic.List[string]]::new()
 $keptOpenSession = $null
 
+$nodeCount = 0
 foreach ($version in $Versions) {
     $properties = Get-TestNodeProperties -RepoRoot $RepoRoot -Version $version
     $server = $null
     try {
         # Key the server runtime directory by port so concurrent invocations on different
         # ports never share a world/logs/server.properties directory.
-        $serverNodeId = if ($KeepOpen) { "$version-$($Loaders[0])-$Port" } else { "$version-$Port" }
+        $serverNodeId = if ($KeepOpen) { "$version-$((Select-TestVersionLoaders -Version $version -Requested $Loaders)[0])-$Port" } else { "$version-$Port" }
         $server = Start-TestVanillaServer -NodeId $serverNodeId -Properties $properties -RuntimeRoot $RuntimeRoot `
             -Port $Port -Motd 'Mighty Architect Client Test'
-        foreach ($loader in $Loaders) {
+        foreach ($loader in (Select-TestVersionLoaders -Version $version -Requested $Loaders)) {
+            $nodeCount++
             $passed = $false
             for ($attempt = 1; $attempt -le 2 -and -not $passed; $attempt++) {
                 try {
@@ -285,4 +290,4 @@ if ($keptOpenSession) {
     return
 }
 
-Write-Host "All $($Versions.Count * $Loaders.Count) client-test nodes passed."
+Write-Host "All $nodeCount client-test nodes passed."

--- a/scripts/run-packaged-client-test-matrix.ps1
+++ b/scripts/run-packaged-client-test-matrix.ps1
@@ -1,6 +1,6 @@
 param(
-    [string[]]$Versions = @('1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
-    [string[]]$Loaders = @('fabric', 'neoforge'),
+    [string[]]$Versions = @('1.19.4', '1.20.1', '1.20.2', '1.20.4', '1.20.6', '1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
+    [string[]]$Loaders = @('fabric', 'neoforge', 'forge'),
     [int]$Port = 25565,
     [int]$ClientTimeoutSeconds = 600,
     [ValidateSet('Always', 'Auto', 'Never')]
@@ -15,7 +15,7 @@ Import-Module (Join-Path $PSScriptRoot 'TestMatrix.Common.psm1') -Force
 Assert-TestMatrixPowerShell
 
 $Versions = Expand-TestListArgument -Value $Versions
-$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge')
+$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge', 'forge')
 
 if (-not $IsWindows) {
     throw 'The packaged matrix currently requires Prism Launcher on Windows.'
@@ -425,6 +425,7 @@ $failures = [System.Collections.Generic.List[string]]::new()
 $keptOpenSessions = [System.Collections.Generic.List[object]]::new()
 $targetIndex = 0
 
+$nodeCount = 0
 foreach ($version in $Versions) {
     $properties = Get-TestNodeProperties -RepoRoot $RepoRoot -Version $version
     $sharedServer = $null
@@ -434,7 +435,8 @@ foreach ($version in $Versions) {
                 -Port $Port -Motd 'Mighty Architect Packaged Client Test'
         }
 
-        foreach ($loader in $Loaders) {
+        foreach ($loader in (Select-TestVersionLoaders -Version $version -Requested $Loaders)) {
+            $nodeCount++
             $instancePort = if ($KeepOpen) { $Port + $targetIndex } else { $Port }
             $targetIndex++
             $server = $sharedServer
@@ -494,5 +496,5 @@ if ($failures.Count -gt 0) {
 }
 
 if ($keptOpenSessions.Count -eq 0) {
-    Write-Host "All $($Versions.Count * $Loaders.Count) packaged client-test nodes passed."
+    Write-Host "All $nodeCount packaged client-test nodes passed."
 }

--- a/scripts/run-server-test-matrix.ps1
+++ b/scripts/run-server-test-matrix.ps1
@@ -1,6 +1,6 @@
 param(
-    [string[]]$Versions = @('1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
-    [string[]]$Loaders = @('fabric', 'neoforge'),
+    [string[]]$Versions = @('1.19.4', '1.20.1', '1.20.2', '1.20.4', '1.20.6', '1.21.1', '1.21.4', '1.21.6', '1.21.8', '1.21.10', '1.21.11', '26.1', '26.2'),
+    [string[]]$Loaders = @('fabric', 'neoforge', 'forge'),
     [int]$TimeoutSeconds = 600
 )
 
@@ -10,7 +10,7 @@ Import-Module (Join-Path $PSScriptRoot 'TestMatrix.Common.psm1') -Force
 Assert-TestMatrixPowerShell
 
 $Versions = Expand-TestListArgument -Value $Versions
-$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge')
+$Loaders = Expand-TestListArgument -Value $Loaders -Allowed @('fabric', 'neoforge', 'forge')
 
 $RepoRoot = Get-TestMatrixRepoRoot -ScriptRoot $PSScriptRoot
 $ResultsRoot = Join-Path (Join-Path $RepoRoot 'build') 'server-test-results'
@@ -77,7 +77,7 @@ function Invoke-ServerTest {
     $arguments.Add(":${Loader}:${Version}:runAutomatedServerTest")
     $arguments.Add('--console=plain')
     $arguments.Add('--no-daemon')
-    $arguments.Add('-Porg.gradle.java.installations.fromEnv=JAVA_HOME_21_X64,JAVA_HOME_25_X64')
+    $arguments.Add('-Porg.gradle.java.installations.fromEnv=JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64')
     $hiddenWindow = Get-TestHiddenWindowOption
     $process = Start-Process -FilePath $Gradle `
         -ArgumentList $arguments `
@@ -127,8 +127,10 @@ function Invoke-ServerTest {
 New-Item -ItemType Directory -Force -Path $ResultsRoot | Out-Null
 $failures = [System.Collections.Generic.List[string]]::new()
 
+$nodeCount = 0
 foreach ($version in $Versions) {
-    foreach ($loader in $Loaders) {
+    foreach ($loader in (Select-TestVersionLoaders -Version $version -Requested $Loaders)) {
+        $nodeCount++
         $passed = $false
         for ($attempt = 1; $attempt -le 2 -and -not $passed; $attempt++) {
             try {
@@ -154,4 +156,4 @@ if ($failures.Count -gt 0) {
     throw "Server-test matrix failed:`n - $($failures -join "`n - ")"
 }
 
-Write-Host "All $($Versions.Count * $Loaders.Count) server-test nodes passed."
+Write-Host "All $nodeCount server-test nodes passed."

--- a/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
+++ b/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
@@ -1,12 +1,10 @@
 package com.timmie.mightyarchitect.test.server;
 
-import com.timmie.mightyarchitect.AllPackets;
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.networking.InstantPrintPacket;
-import io.netty.buffer.Unpooled;
+import com.timmie.mightyarchitect.networking.PacketWire;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
-import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Blocks;
@@ -89,26 +87,20 @@ public final class ServerPrintTest {
     }
 
     /**
-     * Encodes and decodes through the registered stream codec, which is what the loader does on
-     * the wire. A codec that writes and reads asymmetrically corrupts every later field, so the
-     * fully-drained buffer is the assertion that matters most here.
+     * Encodes and decodes the way the loader does on the wire. The encoding itself is version
+     * -variable (stream codecs from 1.20.5, a plain buffer write before that) so it lives behind
+     * {@link PacketWire} in the shared module; the assertions stay here.
      */
     private static InstantPrintPacket roundTrip(MinecraftServer server, InstantPrintPacket packet) {
-        RegistryFriendlyByteBuf buffer =
-            new RegistryFriendlyByteBuf(Unpooled.buffer(), server.registryAccess());
+        PacketWire.RoundTrip result = PacketWire.roundTrip(server.registryAccess(), packet);
 
-        AllPackets.INSTANT_PRINT_CODEC.encode(buffer, packet);
-        int encoded = buffer.readableBytes();
-        require(encoded > 0, "packet encoded to an empty buffer");
-
-        InstantPrintPacket decoded = AllPackets.INSTANT_PRINT_CODEC.decode(buffer);
-        require(buffer.readableBytes() == 0,
-            "decode left " + buffer.readableBytes() + " of " + encoded + " bytes unread");
-        require(decoded.type() == AllPackets.INSTANT_PRINT_TYPE,
-            "decoded payload reports type " + decoded.type());
+        require(result.encodedBytes() > 0, "packet encoded to an empty buffer");
+        require(result.unreadBytes() == 0,
+            "decode left " + result.unreadBytes() + " of " + result.encodedBytes() + " bytes unread");
+        require(result.identityMatches(), "decoded payload reports the wrong packet identity");
 
         passed++;
-        return decoded;
+        return result.packet();
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,11 +18,21 @@ stonecutter {
     centralScript = "build.gradle"
 
     create(rootProject) {
-        versions "1.21.1", "1.21.4", "1.21.6", "1.21.8", "1.21.10", "1.21.11", "26.1", "26.2"
+        versions "1.19.4", "1.20.1", "1.20.2", "1.20.4", "1.20.6", "1.21.1", "1.21.4", "1.21.6", "1.21.8", "1.21.10", "1.21.11", "26.1", "26.2"
         vcsVersion = "26.1"
         branch("common")
         branch("fabric")
-        branch("neoforge")
+        // NeoForge only becomes buildable at 1.20.4: ModDevGradle resolves NeoForge through Gradle
+        // module metadata, and the earliest build that publishes any is 20.4.238 - the 20.2 and
+        // 20.3 lines went EOL without it, so no toolchain we ship can target them.
+        branch("neoforge") {
+            versions "1.20.4", "1.20.6", "1.21.1", "1.21.4", "1.21.6", "1.21.8", "1.21.10", "1.21.11", "26.1", "26.2"
+        }
+        // Forge, for the two versions predating NeoForge. NeoForge 1.20.1 (47.x) is still
+        // Forge-API compatible, so this jar serves both loaders there.
+        branch("forge") {
+            versions "1.19.4", "1.20.1"
+        }
     }
 }
 

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -4,22 +4,37 @@ plugins {
 
 stonecutter.active "26.1" /* [SC] DO NOT EDIT */
 
-// Aggregate task: build every Stonecutter version node for both loaders (the full release set)
-// with one command — `./gradlew buildAll` — so local builds match the CI matrix without naming
-// all 14 node paths by hand.
+// Aggregate task: build every Stonecutter version node for every loader it targets (the full
+// release set) with one command — `./gradlew buildAll` — so local builds match the CI matrix
+// without naming all the node paths by hand. Loader branches cover different version subsets
+// (NeoForge cannot be built before 1.20.4, Forge only covers 1.19.4/1.20.1), so the node list is
+// derived from the projects Stonecutter actually created rather than a hardcoded cross product.
+def loaderNodePaths = { String taskName ->
+    ["fabric", "neoforge", "forge"].collectMany { loader ->
+        stonecutter.versions.collect { v -> rootProject.findProject(":${loader}:${v.project}") }
+    }.findAll { it != null }.collect { "${it.path}:${taskName}" }
+}
+
 tasks.register("buildAll") {
     group = "build"
-    description = "Builds all version nodes for both loaders (Fabric + NeoForge)."
-    dependsOn stonecutter.versions.collect { v ->
-        [":fabric:${v.project}:build", ":neoforge:${v.project}:build"]
-    }.flatten()
+    description = "Builds all version nodes for every loader they target (Fabric + NeoForge + Forge)."
+    dependsOn loaderNodePaths("build")
 }
 
 // Convenience: assemble (no tests/checks) the full release set of jars.
 tasks.register("assembleAll") {
     group = "build"
-    description = "Assembles all version nodes for both loaders without running checks."
-    dependsOn stonecutter.versions.collect { v ->
-        [":fabric:${v.project}:assemble", ":neoforge:${v.project}:assemble"]
-    }.flatten()
+    description = "Assembles all version nodes for every loader they target without running checks."
+    dependsOn loaderNodePaths("assemble")
+}
+
+// Compile-only sweep across every node and every source set, including the test companions. This
+// is the local inner loop the workflow calls for: it catches version-specific compile breakage in
+// a few minutes without launching a single game instance, leaving the runtime matrices to CI.
+tasks.register("compileAll") {
+    group = "verification"
+    description = "Compiles main, client-test and server-test sources for every node and loader."
+    dependsOn loaderNodePaths("compileJava")
+    dependsOn loaderNodePaths("compileClientTestJava")
+    dependsOn loaderNodePaths("compileServerTestJava")
 }

--- a/versions/1.19.4/gradle.properties
+++ b/versions/1.19.4/gradle.properties
@@ -1,0 +1,15 @@
+java_version=17
+unobfuscated=false
+minecraft_version=1.19.4
+# NeoForge does not exist for 1.19.4; this node ships Fabric + Forge.
+
+fabric_loader_version=0.16.14
+fabric_api_version=0.87.2+1.19.4
+forge_version=1.19.4-45.2.0
+
+# Metadata dependency ranges (expanded into fabric.mod.json / the loader's mods toml)
+meta_mc_range=1.19.4
+meta_mc_max=1.20
+meta_pack_format=13
+meta_forge_range=45
+meta_java_range=17

--- a/versions/1.20.1/gradle.properties
+++ b/versions/1.20.1/gradle.properties
@@ -1,0 +1,15 @@
+java_version=17
+unobfuscated=false
+minecraft_version=1.20.1
+# NeoForge 1.20.1 (47.x) is Forge-API compatible, so one Forge jar serves both loaders.
+
+fabric_loader_version=0.16.14
+fabric_api_version=0.92.11+1.20.1
+forge_version=1.20.1-47.3.0
+
+# Metadata dependency ranges (expanded into fabric.mod.json / the loader's mods toml)
+meta_mc_range=1.20
+meta_mc_max=1.20.2
+meta_pack_format=15
+meta_forge_range=47
+meta_java_range=17

--- a/versions/1.20.2/gradle.properties
+++ b/versions/1.20.2/gradle.properties
@@ -1,0 +1,14 @@
+java_version=17
+unobfuscated=false
+minecraft_version=1.20.2
+# Fabric-only. ModDevGradle resolves NeoForge through Gradle module metadata and no 20.2 or
+# 20.3 build ever published any, so NeoForge cannot be built for this version at all.
+
+fabric_loader_version=0.16.14
+fabric_api_version=0.91.6+1.20.2
+
+# Metadata dependency ranges (expanded into fabric.mod.json / the loader's mods toml)
+meta_mc_range=1.20.2
+meta_mc_max=1.20.3
+meta_pack_format=18
+meta_java_range=17

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -1,0 +1,16 @@
+java_version=17
+unobfuscated=false
+minecraft_version=1.20.4
+# 1.20.3 and 1.20.4 share an API surface and pack format, so this node covers both.
+
+fabric_loader_version=0.16.14
+fabric_api_version=0.97.3+1.20.4
+neoforge_version=20.4.251
+
+# Metadata dependency ranges (expanded into fabric.mod.json / the loader's mods toml)
+meta_mc_range=1.20.3
+meta_mc_max=1.20.5
+meta_pack_format=22
+meta_neoforge_range=20.4
+meta_fml_range=2
+meta_java_range=17

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -1,0 +1,16 @@
+java_version=21
+unobfuscated=false
+minecraft_version=1.20.6
+# 1.20.5 and 1.20.6 share the data-component API surface and pack format.
+
+fabric_loader_version=0.16.14
+fabric_api_version=0.100.8+1.20.6
+neoforge_version=20.6.139
+
+# Metadata dependency ranges (expanded into fabric.mod.json / the loader's mods toml)
+meta_mc_range=1.20.5
+meta_mc_max=1.21
+meta_pack_format=32
+meta_neoforge_range=20.6
+meta_fml_range=2
+meta_java_range=21


### PR DESCRIPTION
Brings back the five Minecraft versions the mod supported before the single-branch
migration. The Stonecutter tree stopped at 1.21.1, so 1.19.4, 1.20.1, 1.20.2, 1.20.4 and
1.20.6 have had no updates since — including the composer HUD, palette-picker and
measurement-label fixes that landed on `main`.

**Rebased onto current `main`** (through #34). Everything here is built on the
post-Architectury stack: Fabric Loom + ModDevGradle, one buildscript per loader, shared
Mixins on vanilla classes, vanilla `CustomPacketPayload` networking. No new Architectury
dependency is reintroduced anywhere.

The matrix goes from **8 versions / 16 jars** to **13 versions / 25 jars**.

| MC | Java | Loaders | Metadata |
|---|---|---|---|
| 1.19.4 | 17 | Fabric + Forge | `mods.toml`, `mandatory` |
| 1.20.1 | 17 | Fabric + Forge | `mods.toml`, `mandatory` |
| 1.20.2 | 17 | **Fabric only** | `mods.toml`, `mandatory` |
| 1.20.4 | 17 | Fabric + NeoForge | `mods.toml`, `type` |
| 1.20.6 | 21 | Fabric + NeoForge | `neoforge.mods.toml`, `type` |

## ⚠️ 1.20.2 ships Fabric-only

No NeoForge build in the 20.2 or 20.3 lines ever published Gradle module metadata — the
earliest that does is **20.4.238**, and both lines are EOL, so no more will appear.
ModDevGradle resolves NeoForge through that metadata (`neoforge-moddev-bundle` capability),
so `:neoforge:1.20.2:createMinecraftArtifacts` cannot resolve at all.

The alternative was reintroducing a third toolchain to build one dead loader version, which
is exactly what #33 just removed.

**Note for review:** 1.20.2 has never actually been published — the Modrinth project lists
1.19.2, 1.19.3, 1.19.4, 1.20/1.20.1, 1.21.1, 1.21.4, 1.21.6, 1.21.10 and 1.21.11, and no
1.20.2/1.20.4/1.20.6 release exists. So 1.20.2 is a Fabric-only node serving no existing
audience; it is the cheapest thing in this PR to drop if you would rather not carry it.

NeoForge does not exist for 1.19.4, and NeoForge 1.20.1 (47.x) still loads Forge mods, so
those two nodes ship a Forge jar instead. `settings.gradle` scopes each loader branch to
the versions it targets.

## Forge without Architectury Loom

The `forge/` branch is rebuilt on **`net.neoforged.moddev.legacyforge` 2.0.143** — the same
ModDevGradle version already used for NeoForge, so no new toolchain enters the build. It
carries the Mixin annotation processor and refmap, writes the `MixinConfigs` jar-manifest
attribute (Forge 45/47 predates `[[mixins]]` in `mods.toml` and reads configs from the
manifest), and reobfuscates the client-test jar. `forge/gradle.properties` — architectury-loom's
`loom.platform` — is gone.

## Three networking eras, one packet shape

`javap` on the real jars puts the boundaries here:

- **< 1.20.2** — no `CustomPacketPayload` at all.
- **1.20.2 – 1.20.4** — `CustomPacketPayload` with `id()` + `write(FriendlyByteBuf)`.
- **≥ 1.20.6** — `type()` + `StreamCodec` + `RegistryFriendlyByteBuf`.

A new `platform/MightyPacket` collapses the first two into a single shape, so the only guard
boundary the packet classes ever need is **1.20.5**. `AllPackets` exposes `Type` +
`StreamCodec` above it and `*_ID` + `*_DECODER` below.

Registration then differs per loader: Fabric uses the raw
`ClientPlayNetworking.send(ResourceLocation, FriendlyByteBuf)` channel API for all four
pre-1.20.5 nodes; NeoForge 20.4 uses `RegisterPayloadHandlerEvent` / `IPayloadRegistrar`
(20.6 already matches 21.x); Forge uses `SimpleChannel`. `@Mod(dist = …)` only exists from
NeoForge 20.6, so on 20.4 the main entrypoint gates on `FMLEnvironment.dist` instead.

A new `networking/PacketWire` holds the version-guarded wire round-trip, which keeps
`server-test/` — not a Stonecutter-processed module — version-agnostic while still covering
the print path on the new nodes.

## Other API deltas

Guarded, not forked:

- **`Gui.render`** moves twice (`PoseStack` → `GuiGraphics` at 1.20, `float` →
  `DeltaTracker` at 1.21), so `GuiMixin` and `ClientHooks.renderHud` each carry arms for
  both.
- **`RenderType.CompositeState`** is `public` in Loom's 1.21+ jars and `protected` below, so
  all seven construction sites split at 1.21; the `< 1.21` arms use the same public vanilla
  factories the `≥ 1.21.6` arms already use.
- **`ResourceLocation`** — `new ResourceLocation(ns, path)` through 1.20.6,
  `fromNamespaceAndPath` from 1.21.
- **1.20** introduced `GuiGraphics`; rather than guard ~110 GUI call sites, the pre-1.20
  nodes import a stand-in of the same simple name, so only the import line and the real
  Minecraft overrides differ.

`pack_format`, the FML/Forge loader range, the mixin compatibility level and the metadata
file name are all driven from `versions/<mc>/gradle.properties`.

## Bugs found while verifying

The runtime matrices had never reached these nodes before, and caught four real bugs.

**The composer HUD drew nothing at all on Forge 45/47 and NeoForge 20.4.** Those loaders replace
the vanilla `Gui` instance with a subclass (`ForgeGui` / `ExtendedGui`) whose `render()` override
never calls `super`, so the shared `GuiMixin` was completely inert — silently, with no warning.
All three post `RenderGuiEvent.Post` at exactly the point the mixin targets, so those nodes hook
that instead. NeoForge 20.5 dropped `ExtendedGui` for layered rendering on vanilla's `Gui`, which
is why every newer node was unaffected.

**NeoForge only started reading `META-INF/neoforge.mods.toml` in 20.5.** The 1.20.4 jar shipped
metadata no loader would read, so *nothing* loaded and the dedicated server simply idled until the
600 s timeout — again with no error. `processResources` renames it back below 1.20.5, for the mod
and both test companions.

**`RegisterPayloadHandlerEvent.registrar()` takes the namespace on 20.4** and the protocol version
on 20.5+. Passing the version killed server startup with a `RegistrationFailedException`.

**World-space measurement labels never rendered on any pre-1.21 version.** `HudTextBuffer`
projected each label with `Camera.rotation().invert()`, but before 1.21 that quaternion does not
carry the 180° flip between Minecraft's world heading and −Z-forward eye space — a label eight
blocks ahead came out with clip `w = -8` and was discarded as "behind the camera". The pre-1.21
arms now build the view rotation the way `GameRenderer.renderLevel` does: pitch about X, then
yaw + 180 about Y.

Three build-level problems also kept those matrices from running at all: `run-client-test-matrix.ps1`
only passed `-PenableClientTestMod=true` for `neoforge`; NeoForge 20.2 rejects `type = "required"`
in a dependency; and the legacy-Forge `mixin` extension appends *every* registered config to *every*
run's program arguments, so the client-only config killed the dedicated-server run with a
`MixinInitialisationError`. It also feeds each refmap's `.tsrg` into one shared collection consumed
by every reobfuscation task, with no task dependency, so a plain `build` reobfuscated before the
file existed.

## Verification

- **CI green on all thirteen versions** — build + jar-metadata verification + dedicated-server smoke
  + automated client matrix, 25 jars. `All versions green` covers the lot.
- 7 print checks per node on the server matrix; 26 checks per node on the client matrix.
- `./gradlew compileAll` — green across every node and all three source sets (`main`, `clientTest`,
  `serverTest`).
- Guard integrity scanned: no arm has a `//` comment stranded outside its `/*…*/` body. (That
  failure mode silently turns a disabled arm into live code; it bit Forge 1.20.1 here.)

### Carried forward across the rebase

`main` moved under this branch twice (#31 added 26.2, #34 fixed the label backdrop), so two
things needed re-applying by hand rather than by merge:

- **#34''s backdrop fix now covers all four `HudTextBuffer` arms.** This branch adds two more
  (pre-1.21 and pre-1.20); left alone they would have kept the old hardcoded dark plate and
  reintroduced black-on-black labels on every legacy version.
- **`McCompat.quadBuffer` is guarded at 1.21.** `ByteBufferBuilder` does not exist below it, so
  the method is split into flat arms and the pre-1.21 nodes build their `BufferBuilder` directly.
  Flat, not nested, because a guard cannot nest inside a commented arm.

Also adds a `compileAll` task as the local inner loop, teaches the client matrix to classify
Gradle-level infrastructure failures as retryable, and adds a third Stonecutter guard rule to the
README: **never put a `//` comment between an arm's marker and its `/*` body.**


