### PR TITLE
Gate the serverbound packets, stop touching gamerules, write files atomically

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ The server matrix boots a real dedicated server per target and runs the print-to
 registered stream codec, applied to a real `ServerLevel`, and the resulting blocks are compared
 against the schematic. Booting alone is not a pass — the runner waits for the test's verdict.
 
+The same run covers the serverbound authorization gate in `ServerBuildGuard`: the decode-time
+bounds on both packets, the per-player placement budget and the reach test, and then the gate end
+to end — a real packet handed to the real handler with a real `ServerPlayer`, asserting that an
+authorised sender's build lands and that an out-of-reach or unauthorised one does not.
+
 The packaged runner is artifact-first: Gradle only ever runs in
 `scripts/prepare-runtime-artifacts.ps1`, which builds every requested target once
 and records the resulting jars in `build/runtime-artifacts/manifest.json`. Client

--- a/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
@@ -35,14 +35,9 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.network.chat.Component;
-import org.apache.commons.io.IOUtils;
 import org.lwjgl.glfw.GLFW;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 
 public class ArchitectManager {
 
@@ -156,17 +151,11 @@ public class ArchitectManager {
 		String filename = FilesHelper.findFirstValidFilename(name, folderPath, "nbt");
 		String filepath = folderPath + "/" + filename;
 
-		OutputStream outputStream = null;
-		try {
-			outputStream = Files.newOutputStream(Paths.get(filepath), StandardOpenOption.CREATE);
-			CompoundTag nbttagcompound = getModel().writeToTemplate()
-				.save(new CompoundTag());
-			NbtIo.writeCompressed(nbttagcompound, outputStream);
-		} catch (IOException e) {
-			e.printStackTrace();
-		} finally {
-			if (outputStream != null)
-				IOUtils.closeQuietly(outputStream);
+		CompoundTag nbttagcompound = getModel().writeToTemplate()
+			.save(new CompoundTag());
+		if (!FilesHelper.writeAtomically(Paths.get(filepath), out -> NbtIo.writeCompressed(nbttagcompound, out))) {
+			status("Could not save " + filepath);
+			return;
 		}
 		status("Saved as " + filepath);
 

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
@@ -10,7 +10,6 @@ import net.minecraft.nbt.NbtIo;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.*;
 import java.util.*;
 
@@ -145,15 +144,8 @@ public class ThemeStorage {
 		massiveThemeTag.put("Designs", layers);
 
 		if (compressed) {
-			try {
-				Path path = Paths.get(folderPath + "/" + theme.getFilePath() + ".theme");
-				Files.deleteIfExists(path);
-				OutputStream outputStream = Files.newOutputStream(path, StandardOpenOption.CREATE);
-				NbtIo.writeCompressed(massiveThemeTag, outputStream);
-				outputStream.close();
-			} catch (IOException e) {
-				e.printStackTrace();
-			}
+			Path path = Paths.get(folderPath + "/" + theme.getFilePath() + ".theme");
+			FilesHelper.writeAtomically(path, out -> NbtIo.writeCompressed(massiveThemeTag, out));
 		} else {
 			FilesHelper.saveTagCompoundAsJsonCompact(massiveThemeTag, folderPath + "/" + theme.getFilePath() + ".json");
 		}

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/PrintingToMultiplayer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/PrintingToMultiplayer.java
@@ -34,21 +34,11 @@ public class PrintingToMultiplayer extends PhaseBase {
 
 		success = true;
 
-		// todo: /me doesn't work anymore
-		// String cmd = "me is printing a structure created by the Mighty Architect.";
-		// Minecraft.getInstance().player.connection.sendCommand(cmd);
-		String cmd = "gamerule sendCommandFeedback false";
-		//? if >=1.21.6 {
-		Minecraft.getInstance().player.connection.sendCommand(cmd);
-		//?} else {
-		/*Minecraft.getInstance().player.connection.sendUnsignedCommand(cmd);
-		*///?}
-		cmd = "gamerule logAdminCommands false";
-		//? if >=1.21.6 {
-		Minecraft.getInstance().player.connection.sendCommand(cmd);
-		//?} else {
-		/*Minecraft.getInstance().player.connection.sendUnsignedCommand(cmd);
-		*///?}
+		// Printing deliberately does NOT touch the server's gamerules. It used to turn off
+		// sendCommandFeedback and logAdminCommands and turn them back on afterwards, which
+		// silently disabled the server's admin-command audit log for everyone, and left it
+		// disabled for good if the print was interrupted by a crash, kick or disconnect. The
+		// resulting command feedback in chat is the honest cost of building with commands.
 
 		remaining = new LinkedList<>(getModel().getMaterializedSketch().getAllPositions());
 		remaining.sort((o1, o2) -> Integer.compare(o1.getY(), o2.getY()));
@@ -110,24 +100,13 @@ public class PrintingToMultiplayer extends PhaseBase {
 			/*Minecraft.getInstance().player.displayClientMessage(Component.literal(ChatFormatting.GREEN + "Finished Printing, enjoy!"),
 					false);
 			*///?}
-			String cmd = "gamerule logAdminCommands true";
-			//? if >=1.21.6 {
-			Minecraft.getInstance().player.connection.sendCommand(cmd);
-			//?} else {
-			/*Minecraft.getInstance().player.connection.sendUnsignedCommand(cmd);
-			*///?}
-			cmd = "gamerule sendCommandFeedback true";
-			//? if >=1.21.6 {
-			Minecraft.getInstance().player.connection.sendCommand(cmd);
-			//?} else {
-			/*Minecraft.getInstance().player.connection.sendUnsignedCommand(cmd);
-			*///?}
 		}
 	}
 
 	@Override
 	public List<String> getToolTip() {
-		return ImmutableList.of("Please be patient while your building is being transferred.");
+		return ImmutableList.of("Please be patient while your building is being transferred.",
+			"Your server will report each block as it is placed.");
 	}
 
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/FilesHelper.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/FilesHelper.java
@@ -17,8 +17,15 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 
 public class FilesHelper {
@@ -30,6 +37,53 @@ public class FilesHelper {
 			} catch (IOException e) {
 				TheMightyArchitect.logger.warn("Could not create Folder: " + name);
 			}
+		}
+	}
+
+	/** The body of a write, run against a stream that only becomes the real file once it succeeds. */
+	@FunctionalInterface
+	public interface StreamWriter {
+		void writeTo(OutputStream out) throws IOException;
+	}
+
+	/**
+	 * Writes a file without ever leaving a half-written one behind.
+	 * <p>
+	 * The previous pattern here was delete, open, write, close - so a crash anywhere in between
+	 * destroyed the old file and produced nothing in its place. Themes and palettes are hours of
+	 * user work, so instead the content goes to a temporary sibling and only replaces the target
+	 * once it is complete and closed, which the filesystem does atomically.
+	 *
+	 * @return whether the file was written
+	 */
+	public static boolean writeAtomically(Path target, StreamWriter body) {
+		Path directory = target.toAbsolutePath()
+			.getParent();
+		Path temp = target.resolveSibling(target.getFileName() + ".tmp");
+		try {
+			if (directory != null)
+				Files.createDirectories(directory);
+
+			try (OutputStream out = Files.newOutputStream(temp, StandardOpenOption.CREATE,
+				StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+				body.writeTo(out);
+			}
+
+			try {
+				Files.move(temp, target, StandardCopyOption.ATOMIC_MOVE);
+			} catch (AtomicMoveNotSupportedException unsupported) {
+				Files.move(temp, target, StandardCopyOption.REPLACE_EXISTING);
+			}
+			return true;
+
+		} catch (IOException e) {
+			TheMightyArchitect.logger.error("Could not write " + target, e);
+			try {
+				Files.deleteIfExists(temp);
+			} catch (IOException cleanup) {
+				TheMightyArchitect.logger.warn("Could not remove the leftover " + temp, cleanup);
+			}
+			return false;
 		}
 	}
 
@@ -51,31 +105,21 @@ public class FilesHelper {
 	}
 
 	public static boolean saveTagCompoundAsJson(CompoundTag compound, String path) {
-		try {
-			Files.deleteIfExists(Paths.get(path));
-			JsonWriter writer = new JsonWriter(Files.newBufferedWriter(Paths.get(path), StandardOpenOption.CREATE));
-			writer.setIndent("  ");
-			Streams.write(JsonParser.parseString(compound.toString()), writer);
-			writer.close();
-			return true;
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return false;
+		return saveTagCompoundAsJson(compound, path, "  ");
 	}
 
 	public static boolean saveTagCompoundAsJsonCompact(CompoundTag compound, String path) {
-		try {
-			Files.deleteIfExists(Paths.get(path));
-			JsonWriter writer = new JsonWriter(Files.newBufferedWriter(Paths.get(path), StandardOpenOption.CREATE));
-			Streams.write(JsonParser.parseString(compound.toString()), writer);
-			writer.close();
-			return true;
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
-		return false;
+		return saveTagCompoundAsJson(compound, path, "");
+	}
 
+	private static boolean saveTagCompoundAsJson(CompoundTag compound, String path, String indent) {
+		return writeAtomically(Paths.get(path), out -> {
+			try (Writer stream = new OutputStreamWriter(out, StandardCharsets.UTF_8);
+				JsonWriter writer = new JsonWriter(stream)) {
+				writer.setIndent(indent);
+				Streams.write(JsonParser.parseString(compound.toString()), writer);
+			}
+		});
 	}
 
 	public static CompoundTag loadJsonNBT(InputStream inputStream) {

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/DetachedServerPlayer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/DetachedServerPlayer.java
@@ -1,0 +1,39 @@
+package com.timmie.mightyarchitect.networking;
+
+import com.mojang.authlib.GameProfile;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+/**
+ * Builds a {@link ServerPlayer} with no network connection behind it, so the automated
+ * dedicated-server test can drive {@link ServerBuildGuard} with a real player against a real level
+ * rather than only exercising the pure halves of it.
+ * <p>
+ * This lives in {@code common/} rather than in the server-test companion for the same reason
+ * {@link PacketWire} does: the constructor gained a {@code ClientInformation} argument in 1.20.2 and
+ * the test modules are not Stonecutter-processed. Nothing in the mod's own code paths calls it.
+ * <p>
+ * A player built this way is safe to ask about permissions and game mode - {@code permissions()}
+ * resolves through the server rather than the connection, and {@code onUpdateAbilities} returns
+ * early when there is no connection - but it is not registered with the level or the player list,
+ * so it must not be used for anything that expects a connected player.
+ */
+public final class DetachedServerPlayer {
+
+	private DetachedServerPlayer() {
+	}
+
+	public static ServerPlayer create(MinecraftServer server, ServerLevel level, String name) {
+		GameProfile profile = new GameProfile(UUID.nameUUIDFromBytes(name.getBytes(StandardCharsets.UTF_8)), name);
+		//? if >=1.20.2 {
+		return new ServerPlayer(server, level, profile,
+			net.minecraft.server.level.ClientInformation.createDefault());
+		//?} else {
+		/*return new ServerPlayer(server, level, profile);
+		*///?}
+	}
+}

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/InstantPrintPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/InstantPrintPacket.java
@@ -17,10 +17,14 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 //?} else {
 /*import net.minecraft.resources.ResourceLocation;
 *///?}
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
+import io.netty.handler.codec.DecoderException;
+
 import java.util.*;
+import java.util.function.Predicate;
 
 public class InstantPrintPacket implements MightyPacket {
 
@@ -37,6 +41,11 @@ public class InstantPrintPacket implements MightyPacket {
 	*///?}
 		// Store raw NBT data to decode on server side with proper registry
 		int size = buf.readInt();
+		// sendSchematic never emits more than MAX_SIZE per packet, so anything larger is either
+		// corrupt or hostile - and this loop allocates per iteration.
+		if (size < 0 || size > BunchOfBlocks.MAX_SIZE)
+			throw new DecoderException(
+				"InstantPrintPacket declared " + size + " blocks; the limit is " + BunchOfBlocks.MAX_SIZE);
 		this.blocks = new BunchOfBlocks(new HashMap<>());
 		this.blocks.rawData = new ArrayList<>();
 		this.blocks.size = size;
@@ -77,28 +86,46 @@ public class InstantPrintPacket implements MightyPacket {
 	}
 
 	public static void handle(InstantPrintPacket packet, PacketContext context) {
-		// Entity.level() replaced the public level field in 1.20.
-		//? if >=1.20 {
-		context.enqueue(() -> apply(context.player().level(), packet));
-		//?} else {
-		/*context.enqueue(() -> apply(context.player().level, packet));
-		*///?}
+		ServerPlayer player = context.player();
+		context.enqueue(() -> {
+			if (!ServerBuildGuard.mayBuild(player)) {
+				ServerBuildGuard.reportDenied(player, "print blocks");
+				return;
+			}
+			if (!ServerBuildGuard.claimBlockBudget(player, packet.blocks.size))
+				return;
+			apply(ServerBuildGuard.levelOf(player), packet, pos -> ServerBuildGuard.mayBuildAt(player, pos));
+		});
 	}
 
-	// Separated from handle so the automated server test can drive the same placement logic
-	// against a real ServerLevel without needing a connected player.
+	/**
+	 * Places every block in the packet, unconditionally.
+	 * <p>
+	 * <b>Unauthorised.</b> Anything that got this packet off the wire must go through
+	 * {@link ServerBuildGuard} first - {@link #handle} does. This overload exists for the automated
+	 * server test, which drives the same placement logic against a real {@code ServerLevel} without
+	 * a connected player to authorise.
+	 */
 	public static void apply(Level level, InstantPrintPacket packet) {
+		apply(level, packet, pos -> true);
+	}
+
+	/** Places the blocks the given filter accepts; see {@link ServerBuildGuard#mayBuildAt}. */
+	public static void apply(Level level, InstantPrintPacket packet, Predicate<BlockPos> allowed) {
 		var holderGetter = level.holderLookup(Registries.BLOCK);
 		if (packet.blocks.rawData != null) {
 			// Decode from raw data on server side
 			for (BlockData data : packet.blocks.rawData) {
+				if (!allowed.test(data.pos))
+					continue;
 				BlockState state = NbtUtils.readBlockState(holderGetter, data.tag);
 				level.setBlock(data.pos, state, 3);
 			}
 		} else {
 			// Already decoded (shouldn't happen for C2S)
 			packet.blocks.blocks.forEach((pos, state) -> {
-				level.setBlock(pos, state, 3);
+				if (allowed.test(pos))
+					level.setBlock(pos, state, 3);
 			});
 		}
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/PacketWire.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/PacketWire.java
@@ -2,6 +2,7 @@ package com.timmie.mightyarchitect.networking;
 
 import com.timmie.mightyarchitect.AllPackets;
 import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.DecoderException;
 import net.minecraft.core.RegistryAccess;
 //? if >=1.20.5 {
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -45,5 +46,48 @@ public final class PacketWire {
 		boolean identity = decoded.id().equals(AllPackets.INSTANT_PRINT_ID);
 		*///?}
 		return new RoundTrip(decoded, encoded, buffer.readableBytes(), identity);
+	}
+
+	/**
+	 * Whether the {@link InstantPrintPacket} decoder refuses a payload declaring this many blocks.
+	 * <p>
+	 * The block count is read straight off the wire and drives an allocating loop, so it has to be
+	 * checked before it is used. Building the hostile buffer is version-variable in the same way
+	 * {@link #roundTrip} is, which is why the assertion is expressed as a boolean here rather than
+	 * left to the (version-agnostic) test module.
+	 */
+	public static boolean instantPrintRejectsSize(RegistryAccess registries, int declaredSize) {
+		try {
+			//? if >=1.20.5 {
+			RegistryFriendlyByteBuf buffer = new RegistryFriendlyByteBuf(Unpooled.buffer(), registries);
+			buffer.writeInt(declaredSize);
+			AllPackets.INSTANT_PRINT_CODEC.decode(buffer);
+			//?} else {
+			/*FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer());
+			buffer.writeInt(declaredSize);
+			AllPackets.INSTANT_PRINT_DECODER.apply(buffer);
+			*///?}
+			return false;
+		} catch (DecoderException rejected) {
+			return true;
+		}
+	}
+
+	/** Whether the {@link SetHotbarItemPacket} decoder refuses a payload addressing this slot. */
+	public static boolean setHotbarItemRejectsSlot(RegistryAccess registries, int slot) {
+		try {
+			//? if >=1.20.5 {
+			RegistryFriendlyByteBuf buffer = new RegistryFriendlyByteBuf(Unpooled.buffer(), registries);
+			buffer.writeInt(slot);
+			AllPackets.SET_HOTBAR_ITEM_CODEC.decode(buffer);
+			//?} else {
+			/*FriendlyByteBuf buffer = new FriendlyByteBuf(Unpooled.buffer());
+			buffer.writeInt(slot);
+			AllPackets.SET_HOTBAR_ITEM_DECODER.apply(buffer);
+			*///?}
+			return false;
+		} catch (DecoderException rejected) {
+			return true;
+		}
 	}
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/PlaceSignPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/PlaceSignPacket.java
@@ -15,6 +15,7 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 /*import net.minecraft.resources.ResourceLocation;
 *///?}
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.SignBlockEntity;
@@ -72,17 +73,19 @@ public class PlaceSignPacket implements MightyPacket {
 	}
 
 	public static void handle(PlaceSignPacket packet, PacketContext context) {
+		ServerPlayer player = context.player();
 		context.enqueue(() -> {
-			// Entity.level() replaced the public level field in 1.20.
-			//? if >=1.20 {
-			Level entityWorld = context.player().level();
-			//?} else {
-			/*Level entityWorld = context.player().level;
-			*///?}
-			entityWorld.setBlockAndUpdate(packet.position, Blocks.SPRUCE_SIGN.defaultBlockState());
-			SignBlockEntity sign = (SignBlockEntity) entityWorld.getBlockEntity(packet.position);
+			if (!ServerBuildGuard.mayBuildAt(player, packet.position)) {
+				ServerBuildGuard.reportDenied(player, "place a design sign");
+				return;
+			}
+			if (!ServerBuildGuard.claimBlockBudget(player, 1))
+				return;
 
-			if (sign != null) {
+			Level entityWorld = ServerBuildGuard.levelOf(player);
+			entityWorld.setBlockAndUpdate(packet.position, Blocks.SPRUCE_SIGN.defaultBlockState());
+
+			if (entityWorld.getBlockEntity(packet.position) instanceof SignBlockEntity sign) {
 				//? if >=1.20 {
 				sign.setText(new SignText().setMessage(0, Component.literal(packet.text1)).setMessage(1, Component.literal(packet.text2)), true);
 				//?} else {

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/ServerBuildGuard.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/ServerBuildGuard.java
@@ -1,0 +1,230 @@
+package com.timmie.mightyarchitect.networking;
+
+import com.timmie.mightyarchitect.TheMightyArchitect;
+import net.minecraft.ChatFormatting;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * The single authorization gate every serverbound packet in this mod passes through before it is
+ * allowed to change anything.
+ * <p>
+ * The packets register as <em>global</em> serverbound receivers on every loader, so any client that
+ * has the mod can send them to any server that also has it. Without a gate that means arbitrary
+ * block placement at arbitrary coordinates by anyone. The rules here deliberately mirror what the
+ * same player could already do by hand or with vanilla commands, so an authorised build behaves
+ * exactly as before and an unauthorised one is simply dropped:
+ * <ul>
+ * <li><b>Who</b> - creative mode, or permission level 2, which is what vanilla requires for
+ * {@code /setblock}. The client already applies the same test before offering multiplayer
+ * printing.</li>
+ * <li><b>Where</b> - inside the world, in a loaded chunk, within reach, and somewhere the player is
+ * allowed to interact with. Delegating the last one to {@link Level#mayInteract} is what makes the
+ * packets respect the world border, spawn protection and claim mods.</li>
+ * <li><b>How much</b> - a per-player token bucket, so a client cannot pin the server thread with an
+ * unbounded stream of placements.</li>
+ * </ul>
+ * Everything here runs on the server thread, on the server side, for a real connected player.
+ */
+public final class ServerBuildGuard {
+
+	/** What vanilla asks for before it will run {@code /setblock}. */
+	private static final int COMMAND_PERMISSION_LEVEL = 2;
+
+	/**
+	 * Furthest a packet may place a block from the player who sent it. A composer build is put down
+	 * around the player and has to be in view to be positioned at all, so this only has to be
+	 * generous enough to cover a large building plus the distance the player may have stepped back
+	 * to look at it.
+	 */
+	public static final int MAX_BUILD_DISTANCE = 256;
+
+	/**
+	 * Blocks a single player may place through mod packets in one burst. Printing has always sent a
+	 * whole schematic in one go, so this has to clear any build the composer can realistically
+	 * produce - a 64x64x64 solid cube - while still being a bound.
+	 */
+	public static final int BLOCK_BUDGET_BURST = 262_144;
+
+	/** Sustained refill once the burst is spent, in blocks per second. */
+	public static final int BLOCK_BUDGET_PER_SECOND = 32_768;
+
+	/** A bucket that has been full and untouched for this long carries no state worth keeping. */
+	private static final long BUDGET_IDLE_TIMEOUT_NANOS = 60L * 1_000_000_000L;
+
+	private static final Map<UUID, Budget> budgets = new HashMap<>();
+
+	private ServerBuildGuard() {
+	}
+
+	/**
+	 * Whether this player is allowed to change the world through the mod at all. Creative mode or
+	 * permission level 2, the same bar vanilla sets for {@code /setblock}.
+	 */
+	public static boolean mayBuild(ServerPlayer player) {
+		if (player == null)
+			return false;
+		if (player.isCreative())
+			return true;
+		// Numeric permission levels were replaced by named permissions in 1.21.11.
+		//? if >=1.21.11 {
+		return player.permissions()
+			.hasPermission(net.minecraft.server.permissions.Permissions.COMMANDS_GAMEMASTER);
+		//?} else {
+		/*return player.hasPermissions(COMMAND_PERMISSION_LEVEL);
+		*///?}
+	}
+
+	/**
+	 * Whether this player is allowed to change this particular block. Adds the positional checks to
+	 * {@link #mayBuild}: a real position inside a loaded chunk, within reach, and not somewhere the
+	 * player is barred from interacting with.
+	 */
+	public static boolean mayBuildAt(ServerPlayer player, BlockPos pos) {
+		if (!mayBuild(player) || pos == null)
+			return false;
+
+		Level level = levelOf(player);
+		if (!level.isInWorldBounds(pos) || !level.isLoaded(pos))
+			return false;
+		if (!withinReach(player.getX(), player.getY(), player.getZ(), pos))
+			return false;
+
+		// mayInteract widened its first parameter from Player to Entity in 1.21.6; ServerPlayer
+		// satisfies both, so the call itself needs no guard.
+		return level.mayInteract(player, pos);
+	}
+
+	/**
+	 * Distance half of {@link #mayBuildAt}, split out so it can be exercised without a live player.
+	 * Measured to the centre of the block.
+	 */
+	public static boolean withinReach(double x, double y, double z, BlockPos pos) {
+		double dx = pos.getX() + 0.5 - x;
+		double dy = pos.getY() + 0.5 - y;
+		double dz = pos.getZ() + 0.5 - z;
+		return dx * dx + dy * dy + dz * dz <= (double) MAX_BUILD_DISTANCE * MAX_BUILD_DISTANCE;
+	}
+
+	/**
+	 * Takes {@code blocks} out of the player's placement budget, or refuses if there is not enough
+	 * left. A refusal is reported to the player, because the alternative is silently dropping part
+	 * of a build.
+	 */
+	public static synchronized boolean claimBlockBudget(ServerPlayer player, int blocks) {
+		if (player == null)
+			return false;
+
+		long now = System.nanoTime();
+		pruneIdleBudgets(now);
+
+		Budget budget = budgets.computeIfAbsent(player.getUUID(), id -> new Budget(now));
+		if (budget.claim(blocks, now))
+			return true;
+
+		// Only on the way into the throttle: while it holds, every further packet would otherwise
+		// repeat this, which is itself a spam vector.
+		if (budget.reportThrottle()) {
+			TheMightyArchitect.logger.warn("Throttled {} blocks from {}: over the {} blocks/s build budget",
+				blocks, player.getName()
+					.getString(),
+				BLOCK_BUDGET_PER_SECOND);
+			player.sendSystemMessage(Component.literal(ChatFormatting.RED
+				+ "The Mighty Architect is placing blocks faster than the server allows; part of this build was skipped."));
+		}
+		return false;
+	}
+
+	/**
+	 * Whether this player may have items put into their hotbar by the mod. Deliberately stricter
+	 * than {@link #mayBuild}: handing out items is not building, and an operator in survival should
+	 * not get free items out of it.
+	 */
+	public static boolean mayReceiveHotbarKit(ServerPlayer player) {
+		return player != null && player.isCreative();
+	}
+
+	/** Records that a packet was refused, without giving a client a way to spam the server log. */
+	public static void reportDenied(ServerPlayer player, String action) {
+		if (TheMightyArchitect.logger.isDebugEnabled())
+			TheMightyArchitect.logger.debug("Refused a request to {} for {}: not authorised", action,
+				player == null ? "an unknown player"
+					: player.getName()
+						.getString());
+	}
+
+	/** Entity.level() replaced the public level field in 1.20. */
+	public static Level levelOf(ServerPlayer player) {
+		//? if >=1.20 {
+		return player.level();
+		//?} else {
+		/*return player.level;
+		*///?}
+	}
+
+	/**
+	 * Drops buckets that are full and have not been touched recently. Recreating one gives a full
+	 * bucket, so this cannot change the outcome of a later claim - it only stops disconnected
+	 * players accumulating in the map.
+	 */
+	private static void pruneIdleBudgets(long now) {
+		if (budgets.size() < 64)
+			return;
+		Iterator<Budget> iterator = budgets.values()
+			.iterator();
+		while (iterator.hasNext())
+			if (iterator.next()
+				.isIdle(now))
+				iterator.remove();
+	}
+
+	/**
+	 * A plain token bucket, with the clock passed in so the throttle can be tested rather than
+	 * assumed.
+	 */
+	public static final class Budget {
+
+		private double blocks = BLOCK_BUDGET_BURST;
+		private long lastRefillNanos;
+		private boolean throttled;
+
+		public Budget(long nowNanos) {
+			this.lastRefillNanos = nowNanos;
+		}
+
+		public boolean claim(int requested, long nowNanos) {
+			blocks = Math.min(BLOCK_BUDGET_BURST, blocks + refillSince(nowNanos));
+			lastRefillNanos = nowNanos;
+
+			if (requested < 0 || blocks < requested)
+				return false;
+			blocks -= requested;
+			throttled = false;
+			return true;
+		}
+
+		/** True the first time a throttle is hit, so the report happens once per episode. */
+		boolean reportThrottle() {
+			if (throttled)
+				return false;
+			throttled = true;
+			return true;
+		}
+
+		boolean isIdle(long nowNanos) {
+			return nowNanos - lastRefillNanos > BUDGET_IDLE_TIMEOUT_NANOS
+				&& blocks + refillSince(nowNanos) >= BLOCK_BUDGET_BURST;
+		}
+
+		private double refillSince(long nowNanos) {
+			return Math.max(0, (nowNanos - lastRefillNanos) / 1_000_000_000.0 * BLOCK_BUDGET_PER_SECOND);
+		}
+	}
+}

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/SetHotbarItemPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/SetHotbarItemPacket.java
@@ -13,10 +13,15 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 //?} else {
 /*import net.minecraft.resources.ResourceLocation;
 *///?}
-import net.minecraft.world.entity.player.Player;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
+import io.netty.handler.codec.DecoderException;
+
 public class SetHotbarItemPacket implements MightyPacket {
+
+	/** The packet only ever addresses the hotbar; anything else is not something to honour. */
+	private static final int HOTBAR_SIZE = 9;
 
 	private final int slot;
 	private final ItemStack stack;
@@ -30,15 +35,24 @@ public class SetHotbarItemPacket implements MightyPacket {
 	// carries the item itself.
 	//? if >=1.20.5 {
 	public SetHotbarItemPacket(RegistryFriendlyByteBuf buffer) {
-		this.slot = buffer.readInt();
+		this.slot = validateSlot(buffer.readInt());
 		this.stack = ItemStack.OPTIONAL_STREAM_CODEC.decode(buffer);
 	}
 	//?} else {
 	/*public SetHotbarItemPacket(FriendlyByteBuf buffer) {
-		this.slot = buffer.readInt();
+		this.slot = validateSlot(buffer.readInt());
 		this.stack = buffer.readItem();
 	}
 	*///?}
+
+	// The slot goes straight into Inventory.setItem, so it has to be a slot this packet is allowed
+	// to address before anything else reads it.
+	private static int validateSlot(int slot) {
+		if (slot < 0 || slot >= HOTBAR_SIZE)
+			throw new DecoderException("SetHotbarItemPacket addressed slot " + slot + "; the hotbar is 0.."
+				+ (HOTBAR_SIZE - 1));
+		return slot;
+	}
 
 	@Override
 	//? if >=1.20.5 {
@@ -63,9 +77,15 @@ public class SetHotbarItemPacket implements MightyPacket {
 	*///?}
 
 	public static void handle(SetHotbarItemPacket packet, PacketContext context) {
+		ServerPlayer player = context.player();
 		context.enqueue(() -> {
-			Player player = context.player();
-			if (!player.isCreative())
+			if (!ServerBuildGuard.mayReceiveHotbarKit(player)) {
+				ServerBuildGuard.reportDenied(player, "hand out a toolkit");
+				return;
+			}
+			// The decoder already rejects out-of-range slots; this keeps the invariant local to the
+			// call that depends on it, since a slot that is not a slot corrupts the inventory.
+			if (packet.slot < 0 || packet.slot >= HOTBAR_SIZE)
 				return;
 
 			player.getInventory().setItem(packet.slot, packet.stack);

--- a/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
+++ b/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
@@ -3,8 +3,10 @@ package com.timmie.mightyarchitect.test.server;
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.networking.InstantPrintPacket;
 import com.timmie.mightyarchitect.networking.PacketWire;
+import com.timmie.mightyarchitect.networking.ServerBuildGuard;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.block.Blocks;
@@ -31,6 +33,10 @@ import java.util.Map;
  * They also cover {@code WrappedWorld}, which is client-only from 26.1 onwards and so cannot be
  * loaded here at all.
  * <p>
+ * The second half of the run covers the parts of {@link ServerBuildGuard} that do not need a
+ * connected player: the decode-time bounds on both packets, the per-player placement budget and
+ * the reach test.
+ * <p>
  * Results are written to the server log as {@code [SERVER-TEST]} lines;
  * {@code scripts/run-server-test-matrix.ps1} waits for the {@code RESULT} line.
  */
@@ -46,6 +52,8 @@ public final class ServerPrintTest {
 
     /** Relative position of the palette entry carrying a non-default blockstate property. */
     private static final BlockPos AXIS_PROBE = new BlockPos(0, 0, 2);
+
+    private static final long ONE_SECOND_NANOS = 1_000_000_000L;
 
     private static boolean ran;
     private static int passed;
@@ -78,6 +86,7 @@ public final class ServerPrintTest {
             pass("applied all " + packets.size() + " packets to the level");
 
             verifyPlaced(level, schematic);
+            verifyGuards(server);
 
             TheMightyArchitect.logger.info("{} RESULT PASS ({} checks)", TAG, passed);
         } catch (Throwable failure) {
@@ -154,6 +163,45 @@ public final class ServerPrintTest {
                 && log.getValue(RotatedPillarBlock.AXIS) == Direction.Axis.X,
             "oak log lost its non-default axis through the NBT round-trip: " + log);
         pass("non-default blockstate property survived the packet round-trip");
+    }
+
+    /**
+     * The authorization gate the handlers now go through. These are the parts of it that are pure -
+     * decode-time bounds, the placement budget and the reach test - so they can be asserted here
+     * without a connected player, and so a regression in any of them turns the matrix red rather
+     * than going unnoticed until someone reads the code.
+     */
+    private static void verifyGuards(MinecraftServer server) {
+        RegistryAccess registries = server.registryAccess();
+
+        require(PacketWire.instantPrintRejectsSize(registries, Integer.MAX_VALUE),
+            "InstantPrintPacket accepted a payload declaring Integer.MAX_VALUE blocks");
+        require(PacketWire.instantPrintRejectsSize(registries, -1),
+            "InstantPrintPacket accepted a payload declaring a negative block count");
+        pass("InstantPrintPacket rejects an out-of-range block count at decode time");
+
+        require(PacketWire.setHotbarItemRejectsSlot(registries, 9),
+            "SetHotbarItemPacket accepted a slot past the end of the hotbar");
+        require(PacketWire.setHotbarItemRejectsSlot(registries, -1),
+            "SetHotbarItemPacket accepted a negative slot");
+        pass("SetHotbarItemPacket rejects an out-of-range hotbar slot at decode time");
+
+        ServerBuildGuard.Budget budget = new ServerBuildGuard.Budget(0L);
+        require(budget.claim(ServerBuildGuard.BLOCK_BUDGET_BURST, 0L),
+            "a fresh block budget did not cover one full burst");
+        require(!budget.claim(1, 0L), "the block budget allowed an overdraw");
+        require(budget.claim(ServerBuildGuard.BLOCK_BUDGET_PER_SECOND, ONE_SECOND_NANOS),
+            "one second did not refill the sustained block rate");
+        pass("the per-player block budget refuses an overdraw and refills over time");
+
+        BlockPos withinReach = ORIGIN.offset(0, 0, ServerBuildGuard.MAX_BUILD_DISTANCE - 1);
+        BlockPos outOfReach = ORIGIN.offset(0, 0, ServerBuildGuard.MAX_BUILD_DISTANCE + 8);
+        require(ServerBuildGuard.withinReach(ORIGIN.getX(), ORIGIN.getY(), ORIGIN.getZ(), withinReach),
+            "the reach test rejected a position " + (ServerBuildGuard.MAX_BUILD_DISTANCE - 1) + " blocks away");
+        require(!ServerBuildGuard.withinReach(ORIGIN.getX(), ORIGIN.getY(), ORIGIN.getZ(), outOfReach),
+            "the reach test accepted a position past " + ServerBuildGuard.MAX_BUILD_DISTANCE + " blocks");
+        require(!ServerBuildGuard.mayBuild(null), "the build gate authorised an absent player");
+        pass("the build gate refuses out-of-reach positions and an absent player");
     }
 
     /**

--- a/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
+++ b/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
@@ -1,14 +1,18 @@
 package com.timmie.mightyarchitect.test.server;
 
 import com.timmie.mightyarchitect.TheMightyArchitect;
+import com.timmie.mightyarchitect.networking.DetachedServerPlayer;
 import com.timmie.mightyarchitect.networking.InstantPrintPacket;
 import com.timmie.mightyarchitect.networking.PacketWire;
 import com.timmie.mightyarchitect.networking.ServerBuildGuard;
+import com.timmie.mightyarchitect.platform.PacketContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.RegistryAccess;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.RotatedPillarBlock;
 import net.minecraft.world.level.block.state.BlockState;
@@ -33,9 +37,10 @@ import java.util.Map;
  * They also cover {@code WrappedWorld}, which is client-only from 26.1 onwards and so cannot be
  * loaded here at all.
  * <p>
- * The second half of the run covers the parts of {@link ServerBuildGuard} that do not need a
- * connected player: the decode-time bounds on both packets, the per-player placement budget and
- * the reach test.
+ * The second half of the run covers {@link ServerBuildGuard}: first the parts that need no
+ * connected player - the decode-time bounds on both packets, the per-player placement budget
+ * and the reach test - and then the gate end to end, with a real player, a real packet and real
+ * blocks.
  * <p>
  * Results are written to the server log as {@code [SERVER-TEST]} lines;
  * {@code scripts/run-server-test-matrix.ps1} waits for the {@code RESULT} line.
@@ -87,6 +92,7 @@ public final class ServerPrintTest {
 
             verifyPlaced(level, schematic);
             verifyGuards(server);
+            verifyLiveGate(server, level);
 
             TheMightyArchitect.logger.info("{} RESULT PASS ({} checks)", TAG, passed);
         } catch (Throwable failure) {
@@ -202,6 +208,95 @@ public final class ServerPrintTest {
             "the reach test accepted a position past " + ServerBuildGuard.MAX_BUILD_DISTANCE + " blocks");
         require(!ServerBuildGuard.mayBuild(null), "the build gate authorised an absent player");
         pass("the build gate refuses out-of-reach positions and an absent player");
+    }
+
+    /**
+     * The gate end to end: a real packet, off the wire, handed to the real handler with a real
+     * {@link ServerPlayer}, ending in real blocks or the absence of them.
+     * <p>
+     * {@link #verifyGuards} covers the pure halves. This covers the composition - that an
+     * authorised sender still gets their build, which is the regression that would otherwise be
+     * silent, and that an unauthorised or out-of-reach one does not.
+     * <p>
+     * The probe player is deliberately detached: both loaders deliver play payloads on the server
+     * thread and {@code ServerStartedEvent} already runs there, so the context can run its work
+     * inline and still be faithful to how the handler is really invoked.
+     */
+    private static void verifyLiveGate(MinecraftServer server, ServerLevel level) {
+        ServerPlayer player = DetachedServerPlayer.create(server, level, "GateProbe");
+        // Above the printed slab, in the chunk the test already forced loaded.
+        BlockPos target = ORIGIN.offset(0, 5, 0);
+        clear(level, target);
+
+        setGameMode(player, GameType.CREATIVE);
+        standAt(player, target);
+        printOneBlock(server, player, target);
+        require(level.getBlockState(target).getBlock() == Blocks.STONE,
+            "the gate refused an authorised creative player's own build at " + target);
+        pass("an authorised player's packet places blocks through the live gate");
+
+        clear(level, target);
+        standAt(player, target.offset(ServerBuildGuard.MAX_BUILD_DISTANCE * 2, 0, 0));
+        printOneBlock(server, player, target);
+        require(level.getBlockState(target).isAir(),
+            "the gate placed a block " + (ServerBuildGuard.MAX_BUILD_DISTANCE * 2) + " blocks out of the sender's reach");
+        pass("the live gate refuses a position out of the sender's reach");
+
+        clear(level, target);
+        setGameMode(player, GameType.SURVIVAL);
+        standAt(player, target);
+        printOneBlock(server, player, target);
+        require(level.getBlockState(target).isAir(),
+            "the gate let a player who is neither creative nor an operator place a block");
+        pass("the live gate refuses a player who is neither creative nor an operator");
+
+        clear(level, target);
+    }
+
+    /**
+     * Puts the probe player into a game mode without a client to tell about it.
+     * <p>
+     * Vanilla sets the mode first and only then notifies: {@code onUpdateAbilities} already returns
+     * early when there is no connection, but the tab-list broadcast that follows reads
+     * {@code player.connection.latency()} and throws. By that point the mode has been set, which is
+     * the only part this test needs - so the notification failure is swallowed and the result is
+     * then asserted rather than assumed. A version that reordered those two steps would fail here
+     * instead of quietly testing the wrong game mode.
+     */
+    private static void setGameMode(ServerPlayer player, GameType mode) {
+        try {
+            player.gameMode.changeGameModeForPlayer(mode);
+        } catch (NullPointerException noClientToNotify) {
+            // The mode is already set; only the broadcast to a connection we do not have failed.
+        }
+        require(player.gameMode.getGameModeForPlayer() == mode && player.isCreative() == mode.isCreative(),
+            "could not put the probe player into " + mode + " mode");
+    }
+
+    private static void standAt(ServerPlayer player, BlockPos pos) {
+        player.setPos(pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5);
+    }
+
+    private static void clear(ServerLevel level, BlockPos pos) {
+        level.setBlock(pos, Blocks.AIR.defaultBlockState(), 3);
+        require(level.getBlockState(pos).isAir(), "could not clear " + pos + " before the next gate check");
+    }
+
+    /** Sends one block the way a client does: encoded, decoded, then through {@code handle}. */
+    private static void printOneBlock(MinecraftServer server, ServerPlayer player, BlockPos target) {
+        Map<BlockPos, BlockState> single = Map.of(BlockPos.ZERO, Blocks.STONE.defaultBlockState());
+        for (InstantPrintPacket packet : InstantPrintPacket.sendSchematic(single, target))
+            InstantPrintPacket.handle(roundTrip(server, packet), new PacketContext() {
+                @Override
+                public ServerPlayer player() {
+                    return player;
+                }
+
+                @Override
+                public void enqueue(Runnable work) {
+                    work.run();
+                }
+            });
     }
 
     /**


### PR DESCRIPTION
The three **P0** findings from the [logic audit](https://github.com/TimStewartJ/TheMightyArchitectury) — the ones that are a safety issue for *other people*, or that destroy user data. All three predate the multi-version port; none of them are version-specific, and none of them needed a new guard arm.

---

## P0.1 — the serverbound packets had no authorization at all

`InstantPrintPacket`, `PlaceSignPacket` and `SetHotbarItemPacket` register as **global** serverbound receivers on every loader. Two of them mutated the world with no permission check, no gamemode check, no distance check and no rate limit:

- `InstantPrintPacket.apply()` → `level.setBlock(pos, state, 3)` at arbitrary positions with arbitrary states. Any client carrying the mod could rewrite any loaded chunk on any server that also carried it, at any distance, ignoring spawn protection and claim mods.
- `PlaceSignPacket.handle()` → a spruce sign with attacker-controlled text, anywhere.

New `ServerBuildGuard` is the single gate all three now go through:

| | rule | why that rule |
| --- | --- | --- |
| **who** | creative, or permission level 2 | what vanilla requires for `/setblock`, and what the client already required before it would offer printing at all |
| **where** | in-world, in a loaded chunk, within 256 blocks, and past `Level.mayInteract` | delegating the last one is what makes the packets finally respect the world border, spawn protection and claim mods |
| **how much** | per-player token bucket: 262 144 blocks of burst, refilling at 32 768/s | bounds the work one client can queue onto the server thread |

Handing out toolkit items stays **creative-only** — deliberately stricter than building, since an operator in survival should not get free items out of it.

**Nothing that used to work stops working.** `ArchitectMenu` has always refused the print key outside creative (`case 'p': if (!player.isCreative()) return false;`), so the gate is strictly more permissive than the client's own precondition.

### Decode-time bounds

- `InstantPrintPacket` read an unvalidated `int size` off the wire and looped that many times **allocating per iteration**, never checking it against `BunchOfBlocks.MAX_SIZE` (32). `sendSchematic` never emits more than 32, so anything larger is corrupt or hostile.
- `SetHotbarItemPacket` passed an unvalidated network `slot` straight into `Inventory.setItem`. It now has to be a hotbar slot.

Both reject with `DecoderException`, the same way vanilla rejects a malformed payload.

## P0.2 — printing disabled the server's audit log, and could leave it disabled

`PrintingToMultiplayer.whenEntered()` sent `gamerule sendCommandFeedback false` and `gamerule logAdminCommands false`; `whenExited()` restored them **only if `success`**. A crash, disconnect or kick mid-print left the whole server running without an admin-command audit log, permanently — server-global state, changed for everyone, by one player's client.

It no longer touches gamerules.

> **Tradeoff, stated plainly:** command feedback now appears in chat while a multiplayer print runs. That is the honest price of building with `/setblock`, and the phase tooltip now says so. The real fix is P2.7 — stop building by scraping `BlockState.toString()` into commands — which is out of scope here.

## P0.3 — a crash mid-save destroyed the file

Every save path was `deleteIfExists` → open → write → `close()` outside try-with-resources, so a crash between the delete and the flush lost the file and left nothing in its place. Themes are hours of user work.

`FilesHelper.writeAtomically` writes a temporary sibling and only moves it over the target once the content is complete and closed (`ATOMIC_MOVE`, falling back to a plain replace where the filesystem cannot). Now used by every save path: palettes, designs, `.theme` exports and `.nbt` schematics. It also creates missing parents, which incidentally fixes the silent failure in `ThemeStorage.exportThemeFullyAsFile`.

---

## Verification

**Every API was `javap`'d against the actual jars for all 13 nodes before any code was written**, per the CI-first workflow:

- `Level.mayInteract` widened its first parameter from `Player` to `Entity` at 1.21.6 — `ServerPlayer` satisfies both, so the call needs **no guard**. Confirmed identical in the NeoForge- and Forge-patched jars, which is where a widened signature would have bitten.
- `isCreative`, `isInWorldBounds`, `isLoaded`, `Inventory.getContainerSize`, `distanceToSqr`, `ServerPlayer.sendSystemMessage` — present and identical on all 13.
- `hasPermissions(int)` → `permissions().hasPermission(...)` at 1.21.11 is the one genuine difference, and it reuses the guard shape the client-side check already had.
- `io.netty.handler.codec.DecoderException` — present in both netty 4.1 `netty-codec` and 4.2 `netty-codec-base`, so it spans the whole matrix.

**The gate is tested, not asserted.** Its pure parts now run in `ServerPrintTest` against a real dedicated server on every version: both decode-time rejections, the token bucket refusing an overdraw and refilling over time, and the reach test at either side of the limit. A regression in any of them turns the matrix red.

**Guard count is down, not up:** −2 arms. `context.player().level()` vs `.level` is now behind `ServerBuildGuard.levelOf`, and `PlaceSignPacket` lost its copy.

### Evidence

| | |
| --- | --- |
| CI | **13/13 green** on both commits — build, metadata check, dedicated-server matrix and client matrix on every version |
| server-test checks | 7 → **17** per node |
| guard mechanics | switched the tree to 1.19.4, built `fabric` + `forge`, switched back to 26.1; only the known cosmetic empty-arm churn appeared, on files this PR does not touch the guards of |

**The gate is mutation-tested in both directions.** Each of these was run against a real dedicated server, confirmed red with the expected message, then reverted and confirmed green:

| broken | resulting failure |
| --- | --- |
| `size < 0` dropped from the decode bound | `AssertionError: InstantPrintPacket accepted a payload declaring a negative block count` |
| `blocks < requested` dropped from the token bucket | `AssertionError: the block budget allowed an overdraw` |
| creative branch of `mayBuild` disabled | `AssertionError: the gate refused an authorised creative player's own build at BlockPos{x=0, y=105, z=0}` |
| reach check removed from `mayBuildAt` | `AssertionError: the gate placed a block 512 blocks out of the sender's reach` |

The last two come from the second commit, which closes the one real gap in the first: nothing was executing the *composition* — `handle` wiring the gate to `apply`, `mayBuild` against a real player, `mayBuildAt` against a real level. An inverted condition there would have made printing a silent no-op with the matrix still green, which is precisely what the gate exists to prevent. `ServerPrintTest` now pushes a real packet through the wire codec into the real handler with a real `ServerPlayer` and asserts on real blocks: authorised creative sender places, same sender 512 blocks away does not, same sender in survival does not.

The probe player comes from `DetachedServerPlayer` in `common/`, for the same reason `PacketWire` lives there — the `ServerPlayer` constructor gained a `ClientInformation` argument in 1.20.2 and the test modules are not Stonecutter-processed. Confirmed executing, not merely compiling, on the old arm too: **1.19.4 fabric and forge both report 17 checks.**