### PR TITLE
De-port hardening: vanilla screen dispatch, one HudTextBuffer, accessor mixin instead of reflection

### DIFF
--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -1,6 +1,7 @@
 package com.timmie.mightyarchitect.test;
 
 import com.timmie.mightyarchitect.foundation.compat.McCompat;
+import com.timmie.mightyarchitect.foundation.compat.ScreenInput;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -10,6 +11,7 @@ import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.control.ArchitectManager;
 import com.timmie.mightyarchitect.control.design.DesignTheme;
+import com.timmie.mightyarchitect.control.design.DesignExporter;
 import com.timmie.mightyarchitect.control.design.Sketch;
 import com.timmie.mightyarchitect.control.design.ThemeStorage;
 import com.timmie.mightyarchitect.control.palette.Palette;
@@ -20,12 +22,20 @@ import com.timmie.mightyarchitect.foundation.WrappedWorld;
 import com.timmie.mightyarchitect.foundation.utility.ShaderManager;
 import com.timmie.mightyarchitect.foundation.utility.Shaders;
 import com.timmie.mightyarchitect.gui.ArchitectMenuScreen;
+import com.timmie.mightyarchitect.gui.DesignExporterScreen;
 import com.timmie.mightyarchitect.gui.PalettePickerScreen;
+import com.timmie.mightyarchitect.gui.TextInputPromptScreen;
+import com.timmie.mightyarchitect.gui.widgets.Indicator;
+import com.timmie.mightyarchitect.gui.widgets.Label;
+import com.timmie.mightyarchitect.gui.widgets.ScrollInput;
 import com.timmie.mightyarchitect.test.mixin.ArchitectManagerAccessor;
 import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.Screenshot;
 import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.core.BlockPos;
@@ -60,6 +70,9 @@ public final class ClientTestController {
         START_COMPOSER,
         OPEN_PALETTE,
         CAPTURE_PALETTE_PREVIEW,
+        VERIFY_SCREEN_INPUT,
+        VERIFY_TEXT_INPUT,
+        VERIFY_SCROLL_ROUTING,
         CAPTURE_BLUEPRINT,
         CAPTURE_HUD_VISIBLE,
         CAPTURE_HUD_HIDDEN,
@@ -123,6 +136,8 @@ public final class ClientTestController {
     private static final int PALETTE_GRID_ROWS = 4;
     /** Distinct colours expected in the grid once the block previews actually draw. */
     private static final int MIN_PALETTE_GRID_COLOURS = 40;
+    /** Characters typed at the text prompt; read back from its abort callback on close. */
+    private static final String TYPED_PROBE = "clienttest";
 
     private static final List<String> checks = new ArrayList<>();
     private static Stage stage = Stage.CONNECT;
@@ -141,6 +156,7 @@ public final class ClientTestController {
     private static Path labelBaselineScreenshot;
     private static Path labelTextScreenshot;
     private static Path palettePickerScreenshot;
+    private static String typedText;
     private static int worldRenderFrames;
     private static int hudRenderFrames;
     private static int composerOverlayFrames;
@@ -195,6 +211,9 @@ public final class ClientTestController {
                 case START_COMPOSER -> startComposer(minecraft);
                 case OPEN_PALETTE -> openPalette(minecraft);
                 case CAPTURE_PALETTE_PREVIEW -> capturePalettePreview(minecraft);
+                case VERIFY_SCREEN_INPUT -> verifyScreenInput(minecraft);
+                case VERIFY_TEXT_INPUT -> verifyTextInput(minecraft);
+                case VERIFY_SCROLL_ROUTING -> verifyScrollRouting(minecraft);
                 case CAPTURE_BLUEPRINT -> captureBlueprint(minecraft);
                 case CAPTURE_HUD_VISIBLE -> captureHudVisible(minecraft);
                 case CAPTURE_HUD_HIDDEN -> captureHudHidden(minecraft);
@@ -395,7 +414,6 @@ public final class ClientTestController {
             return;
 
         palettePickerScreenshot = captured;
-        McCompat.setScreen(minecraft, null);
 
         Window window = minecraft.getWindow();
         double scale = window.getGuiScale();
@@ -409,7 +427,160 @@ public final class ClientTestController {
 
         check(colours >= MIN_PALETTE_GRID_COLOURS,
             "palette block previews rendered (" + colours + " distinct colours in grid)");
+        advance(Stage.VERIFY_SCREEN_INPUT);
+    }
+
+    /**
+     * Drives real input at the mod's screens.
+     * <p>
+     * The screens register their widgets with vanilla and let {@code Screen} /
+     * {@code ContainerEventHandler} dispatch clicks, characters and scroll. That is far less code
+     * than re-implementing the dispatch, but it is also invisible to a screenshot: a screen whose
+     * widgets are never registered still draws correctly and simply ignores the mouse. Nothing else
+     * in any matrix clicks, types or scrolls, so these checks are the only thing standing between a
+     * refactor of that layer and shipping dead controls.
+     */
+    private static void verifyScreenInput(Minecraft minecraft) {
+        if (stageTicks < 3)
+            return;
+
+        verifyPaletteClicks(minecraft);
+        advance(Stage.VERIFY_TEXT_INPUT);
+    }
+
+    /**
+     * Clicks two different palette buttons by position and requires the selection to follow. This
+     * covers the whole chain at once: the widgets are in {@code children()}, vanilla dispatches to
+     * them, and hit-testing picks the widget actually under the cursor rather than merely the first
+     * one registered.
+     */
+    private static void verifyPaletteClicks(Minecraft minecraft) {
+        Screen screen = McCompat.currentScreen(minecraft);
+        check(screen instanceof PalettePickerScreen, "palette picker still open for input");
+
+        List<AbstractWidget> widgets = registeredWidgets(screen);
+        check(!widgets.isEmpty(),
+            "screen widgets are registered with vanilla (" + widgets.size() + " in children())");
+
+        Window window = minecraft.getWindow();
+        int gridX = (window.getGuiScaledWidth() - PALETTE_SCREEN_WIDTH) / 2 + PALETTE_GRID_X;
+        int gridY = (window.getGuiScaledHeight() - PALETTE_SCREEN_HEIGHT) / 2 + PALETTE_GRID_Y;
+        List<AbstractWidget> paletteButtons = new ArrayList<>();
+        for (AbstractWidget widget : widgets) {
+            if (!widget.active || !widget.visible)
+                continue;
+            if (widget.getX() < gridX || widget.getX() >= gridX + PALETTE_GRID_COLUMNS * PALETTE_GRID_SPACING)
+                continue;
+            if (widget.getY() < gridY || widget.getY() >= gridY + PALETTE_GRID_ROWS * PALETTE_GRID_SPACING)
+                continue;
+            paletteButtons.add(widget);
+        }
+        check(paletteButtons.size() >= 2,
+            "at least two included-palette buttons to click (" + paletteButtons.size() + ")");
+
+        PaletteDefinition afterFirst = clickCentre(screen, paletteButtons.get(0));
+        PaletteDefinition afterSecond = clickCentre(screen, paletteButtons.get(1));
+        check(afterFirst != afterSecond,
+            "clicking two palette buttons selected two different palettes");
+    }
+
+    private static PaletteDefinition clickCentre(Screen screen, AbstractWidget widget) {
+        double x = widget.getX() + widget.getWidth() / 2.0;
+        double y = widget.getY() + widget.getHeight() / 2.0;
+        check(ScreenInput.click(screen, x, y, 0), "click consumed at " + (int) x + "," + (int) y);
+        return ArchitectManager.getModel().getPrimary();
+    }
+
+    /**
+     * Typing has to reach the text field the screen focused on open. This is the check that would
+     * have caught a wrong answer to "does vanilla's own {@code setInitialFocus} pass steal focus
+     * from the field?", which is otherwise only answerable by disassembly.
+     */
+    private static void verifyTextInput(Minecraft minecraft) {
+        if (stageTicks == 1) {
+            typedText = null;
+            TextInputPromptScreen prompt = new TextInputPromptScreen(value -> {
+            }, value -> typedText = value);
+            prompt.setTitle("Client Test");
+            McCompat.setScreen(minecraft, prompt);
+            return;
+        }
+        if (stageTicks < 4)
+            return;
+
+        if (typedText == null) {
+            Screen prompt = McCompat.currentScreen(minecraft);
+            check(prompt instanceof TextInputPromptScreen, "text prompt opened");
+            check(!registeredWidgets(prompt).isEmpty(), "text prompt registered its widgets");
+            for (char character : TYPED_PROBE.toCharArray())
+                ScreenInput.type(prompt, character);
+            // Closing the prompt without confirming reports the field contents to the abort callback.
+            McCompat.setScreen(minecraft, null);
+            return;
+        }
+
+        check(TYPED_PROBE.equals(typedText),
+            "typed characters reached the focused text field (got \"" + typedText + "\")");
+        advance(Stage.VERIFY_SCROLL_ROUTING);
+    }
+
+    /**
+     * A scroll has to be routed to the scroll input that a label is drawn on top of. The exporter
+     * screen registers its labels <em>before</em> those inputs, and vanilla's {@code getChildAt}
+     * returns the <em>first</em> child under the cursor, so the input is only reachable because the
+     * labels are inactive. Nothing about that is visible in a screenshot.
+     * <p>
+     * This asserts the routing decision rather than delivering a scroll, because {@code ScrollInput}
+     * gates on the hover flag that {@code AbstractWidget.render} computes from the real cursor -
+     * a synthesised scroll at coordinates the cursor is not actually at would be refused by the
+     * widget itself, for reasons that have nothing to do with dispatch.
+     */
+    private static void verifyScrollRouting(Minecraft minecraft) {
+        if (stageTicks == 1) {
+            DesignExporter.setTheme(ThemeStorage.getIncluded().get(0));
+            McCompat.setScreen(minecraft, new DesignExporterScreen());
+            return;
+        }
+        if (stageTicks < 4)
+            return;
+
+        Screen exporter = McCompat.currentScreen(minecraft);
+        check(exporter instanceof DesignExporterScreen, "design exporter opened");
+
+        List<AbstractWidget> decorations = new ArrayList<>();
+        ScrollInput scrollInput = null;
+        for (AbstractWidget widget : registeredWidgets(exporter)) {
+            if (widget instanceof Label || widget instanceof Indicator)
+                decorations.add(widget);
+            else if (scrollInput == null && widget instanceof ScrollInput candidate && candidate.active)
+                scrollInput = candidate;
+        }
+
+        boolean allInert = !decorations.isEmpty();
+        for (AbstractWidget decoration : decorations)
+            allInert &= !decoration.active;
+        check(allInert, "decorative widgets are present and inactive, so they cannot intercept input ("
+            + decorations.size() + " checked)");
+
+        check(scrollInput != null, "exporter screen has a scroll input");
+        double x = scrollInput.getX() + scrollInput.getWidth() / 2.0;
+        double y = scrollInput.getY() + scrollInput.getHeight() / 2.0;
+        check(exporter.getChildAt(x, y).orElse(null) == scrollInput,
+            "hit-testing over the scroll input resolves to it and not to the label drawn on it");
+
+        McCompat.setScreen(minecraft, null);
         advance(Stage.CAPTURE_BLUEPRINT);
+    }
+
+    /** The screen's own widget list, which is vanilla's since the screens stopped keeping one. */
+    private static List<AbstractWidget> registeredWidgets(Screen screen) {
+        List<AbstractWidget> widgets = new ArrayList<>();
+        if (screen == null)
+            return widgets;
+        for (GuiEventListener child : screen.children())
+            if (child instanceof AbstractWidget widget)
+                widgets.add(widget);
+        return widgets;
     }
 
     /**

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
@@ -10,8 +10,17 @@ import com.mojang.blaze3d.vertex.ByteBufferBuilder;
 import com.mojang.blaze3d.vertex.VertexFormat;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+//? if >=26 {
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+//?} else if >=1.20 {
+/*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
+*///?}
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
 
 /**
  * Shims for client API that moved between versions, chiefly in 26.2. Kept in one place so call
@@ -82,6 +91,38 @@ public final class McCompat {
 		return mc.getMainRenderTarget();
 		//?}
 	}
+
+	/**
+	 * The camera's view rotation, ready to be multiplied onto a projection matrix.
+	 * <p>
+	 * 26 exposes this directly. 1.21 has {@code Camera.rotation()}, which maps camera space into
+	 * world space, so the view rotation is its inverse. Before 1.21 that quaternion does not carry
+	 * the 180 degree flip that turns Minecraft's world-space heading into the -Z-forward eye space,
+	 * so the rotation is rebuilt the way {@code GameRenderer.renderLevel} does it: pitch about X,
+	 * then yaw + 180 about Y.
+	 */
+	public static Matrix4f viewRotation(Camera camera) {
+		//? if >=26 {
+		return camera.getViewRotationMatrix(new Matrix4f());
+		//?} else if >=1.21 {
+		/*return new Matrix4f().rotation(camera.rotation())
+			.invert();
+		*///?} else {
+		/*return new Matrix4f().rotateX(camera.getXRot() * ((float) Math.PI / 180f))
+			.rotateY((camera.getYRot() + 180.0f) * ((float) Math.PI / 180f));
+		*///?}
+	}
+
+	/** Draws unshadowed GUI text. 26 renamed {@code drawString} to {@code text}. */
+	//? if >=26 {
+	public static void drawText(GuiGraphicsExtractor gfx, Font font, String text, int x, int y, int color) {
+		gfx.text(font, text, x, y, color, false);
+	}
+	//?} else {
+	/*public static void drawText(GuiGraphics gfx, Font font, String text, int x, int y, int color) {
+		gfx.drawString(font, text, x, y, color, false);
+	}
+	*///?}
 
 	// 26.2 replaced VertexFormat.Mode with com.mojang.blaze3d.PrimitiveTopology, and
 	// ByteBufferBuilder does not exist at all before 1.21 - those nodes build their BufferBuilder

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/ScreenInput.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/ScreenInput.java
@@ -1,0 +1,51 @@
+package com.timmie.mightyarchitect.foundation.compat;
+
+import net.minecraft.client.gui.screens.Screen;
+//? if >=1.21.10 {
+import net.minecraft.client.input.CharacterEvent;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.MouseButtonInfo;
+//?} else {
+/*
+*///?}
+
+/**
+ * Synthesises GUI input against a screen, for the automated client test.
+ * <p>
+ * The test companion is not Stonecutter-processed, so it cannot name these signatures itself - they
+ * moved in 1.21.10, where the raw arguments became {@code MouseButtonEvent} and
+ * {@code CharacterEvent} records. Keeping them here means the whole mod spells the input signatures
+ * in exactly one place, which is only possible because the screens no longer re-dispatch input
+ * themselves.
+ */
+public final class ScreenInput {
+
+	private ScreenInput() {
+	}
+
+	/** Clicks at GUI coordinates. Returns whether the screen consumed the click. */
+	//? if >=1.21.10 {
+	public static boolean click(Screen screen, double x, double y, int button) {
+		return screen.mouseClicked(new MouseButtonEvent(x, y, new MouseButtonInfo(button, 0)), false);
+	}
+	//?} else {
+	/*public static boolean click(Screen screen, double x, double y, int button) {
+		return screen.mouseClicked(x, y, button);
+	}
+	*///?}
+
+	/** Types one character. Returns whether the screen consumed it. */
+	//? if >=26 {
+	public static boolean type(Screen screen, char character) {
+		return screen.charTyped(new CharacterEvent(character));
+	}
+	//?} else if >=1.21.10 {
+	/*public static boolean type(Screen screen, char character) {
+		return screen.charTyped(new CharacterEvent(character, 0));
+	}
+	*///?} else {
+	/*public static boolean type(Screen screen, char character) {
+		return screen.charTyped(character, 0);
+	}
+	*///?}
+}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/HudTextBuffer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/HudTextBuffer.java
@@ -1,284 +1,16 @@
-//? if >=26 {
 package com.timmie.mightyarchitect.foundation.utility;
 
+import com.timmie.mightyarchitect.foundation.compat.McCompat;
 import net.minecraft.client.Camera;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
+//? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-import net.minecraft.world.phys.Vec3;
-import org.joml.Matrix4f;
-import org.joml.Vector4f;
-
-import java.util.ArrayList;
-import java.util.List;
-
-//*
- //* World-space text (measurement labels) is submitted here during the world render pass and drawn as
- //* HUD text during the overlay pass.
- //* <p>
- //* Immediate-mode {@code Font.drawInBatch} into a custom {@code MultiBufferSource} draws a label's
- //* backing geometry but never its glyphs, so the labels are projected from their world position to
- //* screen coordinates and rendered with the GUI text system, which does work.
- //
-public class HudTextBuffer {
-
-	private record Entry(Vec3 pos, String text, int color) {}
-
-	private static final List<Entry> ENTRIES = new ArrayList<>();
-	private static Vec3 cameraPos = Vec3.ZERO;
-
-	//* Clear the buffer at the start of a world render frame. 
-	public static void beginFrame(Vec3 camera) {
-		ENTRIES.clear();
-		cameraPos = camera;
-	}
-
-	//* Submit a world-space label to be drawn as HUD text this frame. 
-	public static void submit(Vec3 worldPos, String text, int color) {
-		if (text == null || text.isEmpty())
-			return;
-		ENTRIES.add(new Entry(worldPos, text, color));
-	}
-
-	//* Draw all submitted labels, projecting each world position to the screen. 
-	public static void render(GuiGraphicsExtractor gfx) {
-		if (ENTRIES.isEmpty())
-			return;
-
-		Minecraft mc = Minecraft.getInstance();
-		Font font = mc.font;
-		Camera camera = com.timmie.mightyarchitect.foundation.compat.McCompat.mainCamera(mc);
-
-		int guiWidth = gfx.guiWidth();
-		int guiHeight = gfx.guiHeight();
-		int pxWidth = mc.getWindow().getWidth();
-		int pxHeight = mc.getWindow().getHeight();
-		if (pxWidth <= 0 || pxHeight <= 0)
-			return;
-
-		float aspect = (float) pxWidth / (float) pxHeight;
-		float fovRad = (float) Math.toRadians(mc.options.fov().get());
-		Matrix4f projectionView = new Matrix4f()
-			.perspective(fovRad, aspect, 0.05f, 1000.0f)
-			.mul(camera.getViewRotationMatrix(new Matrix4f()));
-
-		for (Entry entry : ENTRIES) {
-			Vector4f clip = projectionView.transform(new Vector4f(
-				(float) (entry.pos().x - cameraPos.x),
-				(float) (entry.pos().y - cameraPos.y),
-				(float) (entry.pos().z - cameraPos.z),
-				1.0f));
-
-			if (clip.w() <= 0.0001f)
-				continue; // behind the camera
-
-			float ndcX = clip.x() / clip.w();
-			float ndcY = clip.y() / clip.w();
-			if (ndcX < -1.3f || ndcX > 1.3f || ndcY < -1.3f || ndcY > 1.3f)
-				continue; // well off-screen
-
-			float screenX = (ndcX * 0.5f + 0.5f) * guiWidth;
-			float screenY = (1.0f - (ndcY * 0.5f + 0.5f)) * guiHeight;
-
-			int width = font.width(entry.text());
-			int x = Math.round(screenX - width / 2.0f);
-			int y = Math.round(screenY - font.lineHeight / 2.0f);
-
-			gfx.fill(x - 2, y - 2, x + width + 2, y + font.lineHeight, ColorHelper.labelBackdrop(entry.color()));
-			gfx.text(font, entry.text(), x, y, entry.color(), false);
-		}
-	}
-}
-//?} else if >=1.21 {
-/*package com.timmie.mightyarchitect.foundation.utility;
-
-import net.minecraft.client.Camera;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.world.phys.Vec3;
-import org.joml.Matrix4f;
-import org.joml.Vector4f;
-
-import java.util.ArrayList;
-import java.util.List;
-
-// World-space text (measurement labels) is submitted here during the world render pass and drawn
-// as HUD text during the overlay pass.
-//
-// Immediate-mode Font.drawInBatch into a custom MultiBufferSource draws a label's backing geometry
-// but never its glyphs, so the labels are projected from their world position to screen
-// coordinates and rendered with the GUI text system, which does work.
-public class HudTextBuffer {
-
-	private record Entry(Vec3 pos, String text, int color) {}
-
-	private static final List<Entry> ENTRIES = new ArrayList<>();
-	private static Vec3 cameraPos = Vec3.ZERO;
-
-	// Clear the buffer at the start of a world render frame.
-	public static void beginFrame(Vec3 camera) {
-		ENTRIES.clear();
-		cameraPos = camera;
-	}
-
-	// Submit a world-space label to be drawn as HUD text this frame.
-	public static void submit(Vec3 worldPos, String text, int color) {
-		if (text == null || text.isEmpty())
-			return;
-		ENTRIES.add(new Entry(worldPos, text, color));
-	}
-
-	// Draw all submitted labels, projecting each world position to the screen.
-	public static void render(GuiGraphics gfx) {
-		if (ENTRIES.isEmpty())
-			return;
-
-		Minecraft mc = Minecraft.getInstance();
-		Font font = mc.font;
-		Camera camera = com.timmie.mightyarchitect.foundation.compat.McCompat.mainCamera(mc);
-
-		int guiWidth = gfx.guiWidth();
-		int guiHeight = gfx.guiHeight();
-		int pxWidth = mc.getWindow().getWidth();
-		int pxHeight = mc.getWindow().getHeight();
-		if (pxWidth <= 0 || pxHeight <= 0)
-			return;
-
-		float aspect = (float) pxWidth / (float) pxHeight;
-		float fovRad = (float) Math.toRadians(mc.options.fov().get());
-		// Camera.rotation() maps camera space into world space, so the view matrix is its inverse.
-		Matrix4f projectionView = new Matrix4f()
-			.perspective(fovRad, aspect, 0.05f, 1000.0f)
-			.mul(new Matrix4f().rotation(camera.rotation()).invert());
-
-		for (Entry entry : ENTRIES) {
-			Vector4f clip = projectionView.transform(new Vector4f(
-				(float) (entry.pos().x - cameraPos.x),
-				(float) (entry.pos().y - cameraPos.y),
-				(float) (entry.pos().z - cameraPos.z),
-				1.0f));
-
-			if (clip.w() <= 0.0001f)
-				continue; // behind the camera
-
-			float ndcX = clip.x() / clip.w();
-			float ndcY = clip.y() / clip.w();
-			if (ndcX < -1.3f || ndcX > 1.3f || ndcY < -1.3f || ndcY > 1.3f)
-				continue; // well off-screen
-
-			float screenX = (ndcX * 0.5f + 0.5f) * guiWidth;
-			float screenY = (1.0f - (ndcY * 0.5f + 0.5f)) * guiHeight;
-
-			int width = font.width(entry.text());
-			int x = Math.round(screenX - width / 2.0f);
-			int y = Math.round(screenY - font.lineHeight / 2.0f);
-
-			gfx.fill(x - 2, y - 2, x + width + 2, y + font.lineHeight, ColorHelper.labelBackdrop(entry.color()));
-			gfx.drawString(font, entry.text(), x, y, entry.color(), false);
-		}
-	}
-}
-*///?} else if >=1.20 {
-/*package com.timmie.mightyarchitect.foundation.utility;
-
-import net.minecraft.client.Camera;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
-import net.minecraft.world.phys.Vec3;
-import org.joml.Matrix4f;
-import org.joml.Vector4f;
-
-import java.util.ArrayList;
-import java.util.List;
-
-// World-space text (measurement labels) is submitted here during the world render pass and drawn
-// as HUD text during the overlay pass.
-//
-// Immediate-mode Font.drawInBatch into a custom MultiBufferSource draws a label's backing geometry
-// but never its glyphs, so the labels are projected from their world position to screen
-// coordinates and rendered with the GUI text system, which does work.
-public class HudTextBuffer {
-
-	private record Entry(Vec3 pos, String text, int color) {}
-
-	private static final List<Entry> ENTRIES = new ArrayList<>();
-	private static Vec3 cameraPos = Vec3.ZERO;
-
-	// Clear the buffer at the start of a world render frame.
-	public static void beginFrame(Vec3 camera) {
-		ENTRIES.clear();
-		cameraPos = camera;
-	}
-
-	// Submit a world-space label to be drawn as HUD text this frame.
-	public static void submit(Vec3 worldPos, String text, int color) {
-		if (text == null || text.isEmpty())
-			return;
-		ENTRIES.add(new Entry(worldPos, text, color));
-	}
-
-	// Draw all submitted labels, projecting each world position to the screen.
-	public static void render(GuiGraphics gfx) {
-		if (ENTRIES.isEmpty())
-			return;
-
-		Minecraft mc = Minecraft.getInstance();
-		Font font = mc.font;
-		Camera camera = mc.gameRenderer.getMainCamera();
-
-		int guiWidth = gfx.guiWidth();
-		int guiHeight = gfx.guiHeight();
-		int pxWidth = mc.getWindow().getWidth();
-		int pxHeight = mc.getWindow().getHeight();
-		if (pxWidth <= 0 || pxHeight <= 0)
-			return;
-
-		float aspect = (float) pxWidth / (float) pxHeight;
-		float fovRad = (float) Math.toRadians(mc.options.fov().get());
-		// Before 1.21, Camera.rotation() does not carry the 180 degree flip that turns Minecraft's
-		// world-space heading into the -Z-forward eye space, so build the view rotation the way
-		// GameRenderer.renderLevel does: pitch about X, then yaw + 180 about Y.
-		Matrix4f projectionView = new Matrix4f()
-			.perspective(fovRad, aspect, 0.05f, 1000.0f)
-			.rotateX(camera.getXRot() * ((float) Math.PI / 180f))
-			.rotateY((camera.getYRot() + 180.0f) * ((float) Math.PI / 180f));
-
-		for (Entry entry : ENTRIES) {
-			Vector4f clip = projectionView.transform(new Vector4f(
-				(float) (entry.pos().x - cameraPos.x),
-				(float) (entry.pos().y - cameraPos.y),
-				(float) (entry.pos().z - cameraPos.z),
-				1.0f));
-
-			if (clip.w() <= 0.0001f)
-				continue; // behind the camera
-
-			float ndcX = clip.x() / clip.w();
-			float ndcY = clip.y() / clip.w();
-			if (ndcX < -1.3f || ndcX > 1.3f || ndcY < -1.3f || ndcY > 1.3f)
-				continue; // well off-screen
-
-			float screenX = (ndcX * 0.5f + 0.5f) * guiWidth;
-			float screenY = (1.0f - (ndcY * 0.5f + 0.5f)) * guiHeight;
-
-			int width = font.width(entry.text());
-			int x = Math.round(screenX - width / 2.0f);
-			int y = Math.round(screenY - font.lineHeight / 2.0f);
-
-			gfx.fill(x - 2, y - 2, x + width + 2, y + font.lineHeight, ColorHelper.labelBackdrop(entry.color()));
-			gfx.drawString(font, entry.text(), x, y, entry.color(), false);
-		}
-	}
-}
+//?} else if >=1.20 {
+/*import net.minecraft.client.gui.GuiGraphics;
 *///?} else {
-/*package com.timmie.mightyarchitect.foundation.utility;
-
-import net.minecraft.client.Camera;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.Font;
-import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
+*///?}
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 import org.joml.Vector4f;
@@ -286,12 +18,18 @@ import org.joml.Vector4f;
 import java.util.ArrayList;
 import java.util.List;
 
-// World-space text (measurement labels) is submitted here during the world render pass and drawn
-// as HUD text during the overlay pass.
-//
-// Immediate-mode Font.drawInBatch into a custom MultiBufferSource draws a label's backing geometry
-// but never its glyphs, so the labels are projected from their world position to screen
-// coordinates and rendered with the GUI text system, which does work.
+/**
+ * World-space text (measurement labels) is submitted here during the world render pass and drawn as
+ * HUD text during the overlay pass.
+ * <p>
+ * Immediate-mode {@code Font.drawInBatch} into a custom {@code MultiBufferSource} draws a label's
+ * backing geometry but never its glyphs, so the labels are projected from their world position to
+ * screen coordinates and rendered with the GUI text system, which does work.
+ * <p>
+ * The projection is version-agnostic. Only three things move: the graphics type, the camera view
+ * rotation and the text call - all of which are behind {@link McCompat}, so this file holds one
+ * copy of the logic rather than one per render epoch.
+ */
 public class HudTextBuffer {
 
 	private record Entry(Vec3 pos, String text, int color) {}
@@ -299,51 +37,50 @@ public class HudTextBuffer {
 	private static final List<Entry> ENTRIES = new ArrayList<>();
 	private static Vec3 cameraPos = Vec3.ZERO;
 
-	// Clear the buffer at the start of a world render frame.
+	/** Clear the buffer at the start of a world render frame. */
 	public static void beginFrame(Vec3 camera) {
 		ENTRIES.clear();
 		cameraPos = camera;
 	}
 
-	// Submit a world-space label to be drawn as HUD text this frame.
+	/** Submit a world-space label to be drawn as HUD text this frame. */
 	public static void submit(Vec3 worldPos, String text, int color) {
 		if (text == null || text.isEmpty())
 			return;
 		ENTRIES.add(new Entry(worldPos, text, color));
 	}
 
-	// Draw all submitted labels, projecting each world position to the screen.
-	public static void render(GuiGraphics gfx) {
+	/** Draw all submitted labels, projecting each world position to the screen. */
+	//? if >=26 {
+	public static void render(GuiGraphicsExtractor gfx) {
+	//?} else {
+	/*public static void render(GuiGraphics gfx) {
+	*///?}
 		if (ENTRIES.isEmpty())
 			return;
 
 		Minecraft mc = Minecraft.getInstance();
 		Font font = mc.font;
-		Camera camera = mc.gameRenderer.getMainCamera();
+		Camera camera = McCompat.mainCamera(mc);
 
 		int guiWidth = gfx.guiWidth();
 		int guiHeight = gfx.guiHeight();
-		int pxWidth = mc.getWindow().getWidth();
-		int pxHeight = mc.getWindow().getHeight();
+		int pxWidth = mc.getWindow()
+			.getWidth();
+		int pxHeight = mc.getWindow()
+			.getHeight();
 		if (pxWidth <= 0 || pxHeight <= 0)
 			return;
 
 		float aspect = (float) pxWidth / (float) pxHeight;
-		float fovRad = (float) Math.toRadians(mc.options.fov().get());
-		// Before 1.21, Camera.rotation() does not carry the 180 degree flip that turns Minecraft's
-		// world-space heading into the -Z-forward eye space, so build the view rotation the way
-		// GameRenderer.renderLevel does: pitch about X, then yaw + 180 about Y.
-		Matrix4f projectionView = new Matrix4f()
-			.perspective(fovRad, aspect, 0.05f, 1000.0f)
-			.rotateX(camera.getXRot() * ((float) Math.PI / 180f))
-			.rotateY((camera.getYRot() + 180.0f) * ((float) Math.PI / 180f));
+		float fovRad = (float) Math.toRadians(mc.options.fov()
+			.get());
+		Matrix4f projectionView = new Matrix4f().perspective(fovRad, aspect, 0.05f, 1000.0f)
+			.mul(McCompat.viewRotation(camera));
 
 		for (Entry entry : ENTRIES) {
-			Vector4f clip = projectionView.transform(new Vector4f(
-				(float) (entry.pos().x - cameraPos.x),
-				(float) (entry.pos().y - cameraPos.y),
-				(float) (entry.pos().z - cameraPos.z),
-				1.0f));
+			Vector4f clip = projectionView.transform(new Vector4f((float) (entry.pos().x - cameraPos.x),
+				(float) (entry.pos().y - cameraPos.y), (float) (entry.pos().z - cameraPos.z), 1.0f));
 
 			if (clip.w() <= 0.0001f)
 				continue; // behind the camera
@@ -361,8 +98,7 @@ public class HudTextBuffer {
 			int y = Math.round(screenY - font.lineHeight / 2.0f);
 
 			gfx.fill(x - 2, y - 2, x + width + 2, y + font.lineHeight, ColorHelper.labelBackdrop(entry.color()));
-			gfx.drawString(font, entry.text(), x, y, entry.color(), false);
+			McCompat.drawText(gfx, font, entry.text(), x, y, entry.color());
 		}
 	}
 }
-*///?}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/Shaders.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/Shaders.java
@@ -1,183 +1,112 @@
 package com.timmie.mightyarchitect.foundation.utility;
 
 import com.timmie.mightyarchitect.TheMightyArchitect;
+//? if >=1.21.4 {
+//?} else {
+/*import com.timmie.mightyarchitect.mixin.GameRendererAccessor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.PostChain;
+*///?}
 //? if >=1.21.11 {
 import net.minecraft.resources.Identifier;
-//?} else if >=1.21.4 {
+//?} else {
 /*import net.minecraft.resources.ResourceLocation;
-*///?} else {
-/*import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.resources.ResourceLocation;
 *///?}
 
-//*
- //* Post-processing shader effects for the mod.
- //* Uses the PostChainManager to handle the 1.21.4+ post-processing API.
- //
+/**
+ * The mod's post-processing effects.
+ * <p>
+ * Two eras. 1.21.4 introduced the declarative {@code post_effect} API, which the mod drives through
+ * {@link PostChainManager}. Older versions load a {@code PostChain} through
+ * {@code GameRenderer.loadEffect}, which is not public on any of them; the way in is
+ * {@code GameRendererAccessor}, so the binding is checked when the mixin is applied instead of
+ * being probed at runtime.
+ * <p>
+ * Every guarded arm below is a whole method. The arms deliberately do not share closing braces,
+ * so a change to one cannot silently unbalance another.
+ */
 public enum Shaders {
 
 	//? if >=1.21.4 {
 	Blueprint("blueprint"),
 	None("");
 	//?} else {
-	/*Blueprint("blueprint.json"), None("");
+	/*Blueprint("blueprint.json"),
+	None("");
 	*///?}
 
 	//? if >=1.21.11 {
 	private final Identifier location;
-	//?} else if >=1.21.4 {
+	//?} else {
 	/*private final ResourceLocation location;
-	*///?} else {
-	/*private ResourceLocation location;
 	*///?}
 
-	//? if >=26 {
-	private Shaders(String name) {
-		if (name.isEmpty()) {
-			location = Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, "");
-		} else {
-			// Post chains are loaded from post_effect/<name>.json.
-			// ResourceLocation should just be namespace:name without path prefix or extension
-			location = Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, name);
-		}
-	//?} else if >=1.21.11 {
-	/*private Shaders(String name) {
-		if (name.isEmpty()) {
-			location = Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, "");
-		} else {
-			// In 1.21.4+, post chains are loaded from post_effect/<name>.json
-			// ResourceLocation should just be namespace:name without path prefix or extension
-			location = Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, name);
-		}
-	*///?} else if >=1.21.4 {
-	/*private Shaders(String name) {
-		if (name.isEmpty()) {
-			location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "");
-		} else {
-			// In 1.21.4+, post chains are loaded from post_effect/<name>.json
-			// ResourceLocation should just be namespace:name without path prefix or extension
-			location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, name);
-		}
-	*///?} else if >=1.21 {
-	/*private Shaders(String filename) {
-		location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "shaders/post/" + filename);
-	*///?} else {
-	/*private Shaders(String filename) {
-		location = new ResourceLocation(TheMightyArchitect.ID, "shaders/post/" + filename);
-	*///?}
+	// From 1.21.4 a post chain is addressed as namespace:name and resolved to
+	// post_effect/<name>.json. Before that the location is the literal resource path.
+	//? if >=1.21.11 {
+	Shaders(String name) {
+		location = Identifier.fromNamespaceAndPath(TheMightyArchitect.ID, name);
 	}
+	//?} else if >=1.21.4 {
+	/*Shaders(String name) {
+		location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, name);
+	}
+	*///?} else if >=1.21 {
+	/*Shaders(String filename) {
+		location = ResourceLocation.fromNamespaceAndPath(TheMightyArchitect.ID, "shaders/post/" + filename);
+	}
+	*///?} else {
+	/*Shaders(String filename) {
+		location = new ResourceLocation(TheMightyArchitect.ID, "shaders/post/" + filename);
+	}
+	*///?}
 
-	//*
-	 //* Checks if this shader is currently active.
-	 //*
-	 //* @return true if this shader is the currently active post-processing shader
-	 //
+	/** Whether this effect is the one currently applied; {@link #None} means "nothing applied". */
+	//? if >=1.21.4 {
 	public boolean isActive() {
-		//? if >=1.21.4 {
-		//?} else {
-		/*Minecraft mc = Minecraft.getInstance();
-		PostChain shaderGroup = mc.gameRenderer.currentEffect();
-		return shaderGroup != null && shaderGroup.getName()
+		if (this == None)
+			return !PostChainManager.isShaderActive();
+		return PostChainManager.isShaderActive(location);
+	}
+	//?} else {
+	/*public boolean isActive() {
+		PostChain applied = Minecraft.getInstance().gameRenderer.currentEffect();
+		if (this == None)
+			return applied == null;
+		return applied != null && applied.getName()
 			.equals(location.toString());
 	}
+	*///?}
 
+	/** Applies or clears this effect. */
+	//? if >=1.21.4 {
 	public void setActive(boolean active) {
+		if (!active) {
+			if (isActive())
+				PostChainManager.shutdownShader();
+			return;
+		}
+		if (this == None)
+			PostChainManager.shutdownShader();
+		else
+			PostChainManager.loadShader(location);
+	}
+	//?} else {
+	/*public void setActive(boolean active) {
 		Minecraft mc = Minecraft.getInstance();
-
-		*///?}
 		if (this == None) {
-			//? if >=1.21.4 {
-			return !PostChainManager.isShaderActive();
-			//?} else {
-			/*mc.gameRenderer.shutdownEffect();
-			return;
-			*///?}
-		}
-		//? if >=1.21.4 {
-		return PostChainManager.isShaderActive(location);
-		//?} else {
-		/*
-		if (active && !isActive()) {
-			loadEffect(mc, location);
-			return;
-		}
-
-		if (!active && isActive()) {
 			mc.gameRenderer.shutdownEffect();
 			return;
 		}
-		*///?}
+		if (active == isActive())
+			return;
+		if (!active) {
+			mc.gameRenderer.shutdownEffect();
+			return;
+		}
+		((GameRendererAccessor) mc.gameRenderer).invokeLoadEffect(location);
+		if (!isActive())
+			TheMightyArchitect.logger.error("Unable to load shader {}", location);
 	}
-
-	//? if >=1.21.4 {
-	//*
-	 //* Activates or deactivates this shader.
-	 //*
-	 //* @param active true to activate, false to deactivate
-	 //
-	public void setActive(boolean active) {
-		if (active) {
-			if (this == None) {
-				PostChainManager.shutdownShader();
-			} else {
-				PostChainManager.loadShader(location);
-	//?} else {
-	/*private static void loadEffect(Minecraft mc, ResourceLocation location) {
-		for (java.lang.reflect.Method candidate : findLoadEffectCandidates(mc)) {
-			try {
-				candidate.setAccessible(true);
-				candidate.invoke(mc.gameRenderer, location);
-			} catch (ReflectiveOperationException e) {
-				continue;
 	*///?}
-			}
-		//? if >=1.21.4 {
-		} else {
-			// Only shutdown if this shader is currently active
-			if (isActive()) {
-				PostChainManager.shutdownShader();
-			}
-		//?} else {
-		/*PostChain applied = mc.gameRenderer.currentEffect();
-			if (applied != null && applied.getName()
-				.equals(location.toString()))
-				return;
-		*///?}
-		}
-		//? if >=1.21.4 {
-		//?} else {
-		/*TheMightyArchitect.logger.error("Unable to load shader {}", location);
-		*///?}
-	}
-
-	//*
-	 //* Gets the resource location of this shader.
-	 //*
-	 //* @return The shader's resource location
-	 //
-	//? if >=1.21.11 {
-	public Identifier getLocation() {
-		return location;
-	//?} else if >=1.21.4 {
-	/*public ResourceLocation getLocation() {
-		return location;
-	*///?} else {
-	/*private static java.util.List<java.lang.reflect.Method> findLoadEffectCandidates(Minecraft mc) {
-		java.util.List<java.lang.reflect.Method> candidates = new java.util.ArrayList<>();
-		try {
-			candidates.add(mc.gameRenderer.getClass()
-				.getDeclaredMethod("loadEffect", ResourceLocation.class));
-		} catch (NoSuchMethodException ignored) {
-			// Remapped runtime; fall through to scanning below.
-		}
-		for (java.lang.reflect.Method method : mc.gameRenderer.getClass()
-			.getDeclaredMethods()) {
-			if (method.getParameterCount() == 1 && method.getParameterTypes()[0] == ResourceLocation.class
-				&& method.getReturnType() == Void.TYPE && !candidates.contains(method))
-				candidates.add(method);
-		}
-		return candidates;
-	*///?}
-	}
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/AbstractSimiScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/AbstractSimiScreen.java
@@ -166,7 +166,10 @@ public abstract class AbstractSimiScreen extends Screen {
 		for (GuiEventListener child : children()) {
 			if (!(child instanceof AbstractSimiWidget widget))
 				continue;
-			if (!widget.isHoveredOrFocused() || widget.getToolTip()
+			// Hover, not isHoveredOrFocused: widgets are focusable now that they are registered
+			// with vanilla, and Screen.setInitialFocus focuses one of them on open from 1.20.6.
+			// Keying tooltips off focus would leave one permanently on screen.
+			if (!widget.isHovered() || widget.getToolTip()
 				.isEmpty())
 				continue;
 			//? if >=1.21.6 {

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/AbstractSimiScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/AbstractSimiScreen.java
@@ -10,28 +10,40 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 /*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 //? if >=1.21.10 {
 import net.minecraft.client.input.CharacterEvent;
-import net.minecraft.client.input.KeyEvent;
-import net.minecraft.client.input.MouseButtonEvent;
 //?} else {
 /*
 *///?}
 import net.minecraft.network.chat.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-
+/**
+ * Base class for the mod's window-style screens.
+ * <p>
+ * Widgets are registered with vanilla through {@code Screen.addWidget}, so {@code children()} is
+ * the single widget list and {@code Screen} / {@code ContainerEventHandler} do the dispatching for
+ * clicks, keys, characters, scroll and focus. Re-implementing that dispatch is what used to make
+ * this the mod's most version-sensitive file: five signatures to track by hand, every one of which
+ * moved again in 1.21.10. Vanilla absorbs those changes for free.
+ * <p>
+ * Drawing is still done here, deliberately. The window art has to appear between the background and
+ * the widgets, and {@code Screen.render} draws the background itself on 1.20.2, 1.20.4, 1.20.6 and
+ * 1.21.4 but not on any other supported version, so {@code super.render} cannot be used to draw the
+ * widgets without double-darkening those four.
+ * <p>
+ * Purely decorative widgets ({@code Label}, {@code Indicator}) are inactive, which keeps them out of
+ * vanilla's {@code getChildAt} hit-testing - several of them are registered before, and overlap, a
+ * {@code ScrollInput}.
+ */
 public abstract class AbstractSimiScreen extends Screen {
 
 	protected int sWidth, sHeight;
 	protected int topLeftX, topLeftY;
-	protected List<AbstractWidget> widgets;
 
 	protected AbstractSimiScreen() {
 		super(Component.literal(""));
-		widgets = new ArrayList<>();
 	}
 
 	protected void setWindowSize(int width, int height) {
@@ -67,14 +79,7 @@ public abstract class AbstractSimiScreen extends Screen {
 		renderBackground(poseStack);
 	*///?}
 		renderWindow(ms, mouseX, mouseY, partialTicks);
-		for (AbstractWidget widget : widgets)
-			//? if >=26 {
-			widget.extractRenderState(ms, mouseX, mouseY, partialTicks);
-			//?} else if >=1.20 {
-			/*widget.render(ms, mouseX, mouseY, partialTicks);
-			*///?} else {
-			/*widget.render(ms.pose(), mouseX, mouseY, partialTicks);
-			*///?}
+		renderWidgets(ms, mouseX, mouseY, partialTicks);
 		renderWindowForeground(ms, mouseX, mouseY, partialTicks);
 	}
 
@@ -90,88 +95,51 @@ public abstract class AbstractSimiScreen extends Screen {
 	//?} else {
 	/*
 	*///?}
-	@Override
-	//? if >=1.21.10 {
-	public boolean mouseClicked(MouseButtonEvent event, boolean flag) {
-	//?} else {
-	/*public boolean mouseClicked(double x, double y, int button) {
-	*///?}
-		boolean result = false;
-		for (AbstractWidget widget : widgets) {
-			//? if >=1.21.10 {
-			if (widget.mouseClicked(event, flag))
-			//?} else {
-			/*if (widget.mouseClicked(x, y, button))
-			*///?}
-				result = true;
-		}
-		return result;
+	// The one place the widget draw call has to be spelled per epoch. Everything else about
+	// widgets - storage, ordering, hit-testing, focus - is vanilla's.
+	//? if >=26 {
+	private void renderWidgets(GuiGraphicsExtractor ms, int mouseX, int mouseY, float partialTicks) {
+		for (GuiEventListener child : children())
+			if (child instanceof AbstractWidget widget)
+				widget.extractRenderState(ms, mouseX, mouseY, partialTicks);
 	}
-
-	@Override
-	//? if >=1.21.10 {
-	public boolean keyPressed(KeyEvent event) {
-	//?} else {
-	/*public boolean keyPressed(int code, int p_keyPressed_2_, int p_keyPressed_3_) {
-	*///?}
-		for (AbstractWidget widget : widgets) {
-			//? if >=1.21.10 {
-			if (widget.keyPressed(event))
-			//?} else {
-			/*if (widget.keyPressed(code, p_keyPressed_2_, p_keyPressed_3_))
-			*///?}
-				return true;
-		}
-		//? if >=1.21.10 {
-		return super.keyPressed(event);
-		//?} else {
-		/*return super.keyPressed(code, p_keyPressed_2_, p_keyPressed_3_);
-		*///?}
+	//?} else if >=1.20 {
+	/*private void renderWidgets(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
+		for (GuiEventListener child : children())
+			if (child instanceof AbstractWidget widget)
+				widget.render(ms, mouseX, mouseY, partialTicks);
 	}
+	*///?} else {
+	/*private void renderWidgets(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
+		for (GuiEventListener child : children())
+			if (child instanceof AbstractWidget widget)
+				widget.render(ms.pose(), mouseX, mouseY, partialTicks);
+	}
+	*///?}
 
+	/**
+	 * Closes on the inventory letter, the way an in-game container screen does. Vanilla offers the
+	 * character to the focused widget first, so a text field can still contain that letter.
+	 */
 	@Override
 	//? if >=1.21.10 {
 	public boolean charTyped(CharacterEvent event) {
+		if (super.charTyped(event))
+			return true;
+		return closeOn((char) event.codepoint());
 	//?} else {
 	/*public boolean charTyped(char character, int code) {
+		if (super.charTyped(character, code))
+			return true;
+		return closeOn(character);
 	*///?}
-		for (AbstractWidget widget : widgets) {
-			//? if >=1.21.10 {
-			if (widget.charTyped(event))
-			//?} else {
-			/*if (widget.charTyped(character, code))
-			*///?}
-				return true;
-		}
-		//? if >=1.21.10 {
-		if ((char) event.codepoint() == 'e')
-		//?} else {
-		/*if (character == 'e')
-		*///?}
-			onClose();
-		//? if >=1.21.10 {
-		return super.charTyped(event);
-		//?} else {
-		/*return super.charTyped(character, code);
-		*///?}
 	}
 
-	@Override
-	//? if >=1.20.2 {
-	public boolean mouseScrolled(double mouseX, double mouseY, double horizontalAmount, double verticalAmount) {
-		for (AbstractWidget widget : widgets) {
-			if (widget.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount))
-				return true;
-		}
-		return super.mouseScrolled(mouseX, mouseY, horizontalAmount, verticalAmount);
-	//?} else {
-	/*public boolean mouseScrolled(double mouseX, double mouseY, double verticalAmount) {
-		for (AbstractWidget widget : widgets) {
-			if (widget.mouseScrolled(mouseX, mouseY, verticalAmount))
-				return true;
-		}
-		return super.mouseScrolled(mouseX, mouseY, verticalAmount);
-	*///?}
+	private boolean closeOn(char character) {
+		if (character != 'e')
+			return false;
+		onClose();
+		return true;
 	}
 
 	@Override
@@ -195,35 +163,22 @@ public abstract class AbstractSimiScreen extends Screen {
 	//?} else {
 	/*protected void renderWindowForeground(GuiGraphics ms, int mouseX, int mouseY, float partialTicks) {
 	*///?}
-		for (AbstractWidget widget : widgets) {
-			if (!widget.isHoveredOrFocused())
+		for (GuiEventListener child : children()) {
+			if (!(child instanceof AbstractSimiWidget widget))
 				continue;
-			if (widget instanceof AbstractSimiWidget && !((AbstractSimiWidget) widget).getToolTip()
-				//? if >=26 {
-				.isEmpty()) {
-				// Convert the Component tooltip lines to FormattedCharSequence.
-				java.util.List<net.minecraft.util.FormattedCharSequence> tooltipLines = ((AbstractSimiWidget) widget).getToolTip()
-					.stream()
-					.map(Component::getVisualOrderText)
-					.collect(java.util.stream.Collectors.toList());
-				ms.setTooltipForNextFrame(Minecraft.getInstance().font, tooltipLines, mouseX, mouseY);
-			}
-				//?} else if >=1.21.6 {
-				/*.isEmpty()) {
-				// In 1.21.6, convert Component list to FormattedCharSequence list
-				java.util.List<net.minecraft.util.FormattedCharSequence> tooltipLines = ((AbstractSimiWidget) widget).getToolTip()
-					.stream()
-					.map(Component::getVisualOrderText)
-					.collect(java.util.stream.Collectors.toList());
-				ms.setTooltipForNextFrame(Minecraft.getInstance().font, tooltipLines, mouseX, mouseY);
-			}
-				*///?} else if >=1.20 {
-				/*.isEmpty())
-				ms.renderComponentTooltip(Minecraft.getInstance().font, ((AbstractSimiWidget) widget).getToolTip(), mouseX, mouseY);
-				*///?} else {
-				/*.isEmpty())
-				renderComponentTooltip(ms.pose(), ((AbstractSimiWidget) widget).getToolTip(), mouseX, mouseY);
-				*///?}
+			if (!widget.isHoveredOrFocused() || widget.getToolTip()
+				.isEmpty())
+				continue;
+			//? if >=1.21.6 {
+			ms.setTooltipForNextFrame(Minecraft.getInstance().font, widget.getToolTip()
+				.stream()
+				.map(Component::getVisualOrderText)
+				.toList(), mouseX, mouseY);
+			//?} else if >=1.20 {
+			/*ms.renderComponentTooltip(Minecraft.getInstance().font, widget.getToolTip(), mouseX, mouseY);
+			*///?} else {
+			/*renderComponentTooltip(ms.pose(), widget.getToolTip(), mouseX, mouseY);
+			*///?}
 		}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/DesignExporterScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/DesignExporterScreen.java
@@ -57,7 +57,7 @@ public class DesignExporterScreen extends AbstractSimiScreen {
 	}
 
 	private void initScrollAreas(DesignTheme theme, DesignLayer layer, DesignType type) {
-		widgets.clear();
+		clearWidgets();
 
 		List<DesignLayer> layers = theme.getLayers();
 		labelTheme.setText(theme.getDisplayName());
@@ -87,11 +87,11 @@ public class DesignExporterScreen extends AbstractSimiScreen {
 			.setState(layers.indexOf(layer))
 			.calling(position -> initTypeScrollArea(theme, layers.get(position), DesignExporter.type));
 
-		widgets.add(labelTheme);
-		widgets.add(labelLayer);
-		widgets.add(labelType);
-		widgets.add(labelAdditionalData);
-		widgets.add(scrollAreaLayer);
+		addWidget(labelTheme);
+		addWidget(labelLayer);
+		addWidget(labelType);
+		addWidget(labelAdditionalData);
+		addWidget(scrollAreaLayer);
 
 		initTypeScrollArea(theme, layer, type);
 	}
@@ -123,8 +123,8 @@ public class DesignExporterScreen extends AbstractSimiScreen {
 		List<String> typeOptions = new ArrayList<>();
 		types.forEach(t -> typeOptions.add(t.getDisplayName()));
 
-		if (widgets.contains(scrollAreaType))
-			widgets.remove(scrollAreaType);
+		if (scrollAreaType != null)
+			removeWidget(scrollAreaType);
 
 //		scrollAreaType = new ScrollArea(typeOptions, new IScrollAction() {
 //			@Override
@@ -148,13 +148,13 @@ public class DesignExporterScreen extends AbstractSimiScreen {
 				initAdditionalDataScrollArea(types.get(position));
 			});
 
-		widgets.add(scrollAreaType);
+		addWidget(scrollAreaType);
 		initAdditionalDataScrollArea(type);
 	}
 
 	private void initAdditionalDataScrollArea(DesignType type) {
-		if (widgets.contains(scrollAreaAdditionalData))
-			widgets.remove(scrollAreaAdditionalData);
+		if (scrollAreaAdditionalData != null)
+			removeWidget(scrollAreaAdditionalData);
 
 		if (type.hasAdditionalData()) {
 
@@ -216,7 +216,7 @@ public class DesignExporterScreen extends AbstractSimiScreen {
 			}
 
 			scrollAreaAdditionalData.titled(additionalDataKey);
-			widgets.add(scrollAreaAdditionalData);
+			addWidget(scrollAreaAdditionalData);
 
 		} else {
 

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/PalettePickerScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/PalettePickerScreen.java
@@ -33,6 +33,7 @@ import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Tooltip;
+import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 //? if >=1.21.10 {
 import net.minecraft.client.input.MouseButtonEvent;
@@ -43,6 +44,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 
 import java.nio.file.Paths;
+import java.util.ArrayList;
 
 public class PalettePickerScreen extends AbstractSimiScreen {
 
@@ -71,7 +73,7 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 	public void init() {
 		super.init();
 		setWindowSize(256, 236);
-		widgets.clear();
+		clearWidgets();
 
 		// selected
 		updateSelected();
@@ -81,7 +83,7 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 		int x = topLeftX + 10;
 		int y = topLeftY + 68;
 		for (String paletteName : PaletteStorage.getResourcePaletteNames()) {
-			widgets.add(new PaletteButton(PaletteStorage.getPalette(paletteName), this, id, x + ((id - 2) % 5) * 23,
+			addWidget(new PaletteButton(PaletteStorage.getPalette(paletteName), this, id, x + ((id - 2) % 5) * 23,
 				y + ((id - 2) / 5) * 23));
 			id++;
 		}
@@ -91,7 +93,7 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 		x = topLeftX + 135;
 		y = topLeftY + 68;
 		for (String paletteName : PaletteStorage.getPaletteNames()) {
-			widgets.add(new PaletteButton(PaletteStorage.getPalette(paletteName), this, id + i, x + (i % 5) * 23,
+			addWidget(new PaletteButton(PaletteStorage.getPalette(paletteName), this, id + i, x + (i % 5) * 23,
 				y + (i / 5) * 23));
 			i++;
 		}
@@ -105,17 +107,17 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 			buttonAddPalette.getToolTip()
 				.add(Component.literal("Palette as the template.").withStyle(ChatFormatting.GRAY));
 			i++;
-			widgets.add(buttonAddPalette);
+			addWidget(buttonAddPalette);
 		}
 
 		buttonOpenFolder = new IconButton(x + (i % 5) * 23, y + (i / 5) * 23, ScreenResources.ICON_FOLDER);
 		buttonOpenFolder.setToolTip(Component.literal("Open Palette Folder"));
-		widgets.add(buttonOpenFolder);
+		addWidget(buttonOpenFolder);
 		i++;
 
 		buttonRefresh = new IconButton(x + (i % 5) * 23, y + (i / 5) * 23, ScreenResources.ICON_REFRESH);
 		buttonRefresh.setToolTip(Component.literal("Refresh Imported Palettes"));
-		widgets.add(buttonRefresh);
+		addWidget(buttonRefresh);
 	}
 
 	@Override
@@ -145,8 +147,10 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 	}
 
 	private void updateSelected() {
-		widgets.remove(primary);
-		widgets.remove(secondary);
+		if (primary != null)
+			removeWidget(primary);
+		if (secondary != null)
+			removeWidget(secondary);
 
 		if (scanPicker) {
 			primary = new PaletteButton(DesignExporter.scanningPalette, this, 0, topLeftX + 135, topLeftY + 8);
@@ -154,8 +158,8 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 			secondary = new PaletteButton(DesignExporter.theme.getDefaultSecondaryPalette(), this, 1, topLeftX + 192,
 				topLeftY + 8);
 			secondary.active = false;
-			widgets.add(primary);
-			widgets.add(secondary);
+			addWidget(primary);
+			addWidget(secondary);
 			return;
 		}
 
@@ -165,8 +169,8 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 		secondary = new PaletteButton(ArchitectManager.getModel()
 			.getSecondary(), this, 1, topLeftX + 192, topLeftY + 8);
 		secondary.active = false;
-		widgets.add(primary);
-		widgets.add(secondary);
+		addWidget(primary);
+		addWidget(secondary);
 	}
 
 	@Override
@@ -219,8 +223,10 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 	//?} else {
 	/*public boolean mouseClicked(double mouseX, double mouseY, int mouseButton) {
 	*///?}
-		for (int i = 0; i < this.widgets.size(); ++i) {
-			AbstractWidget guibutton = this.widgets.get(i);
+		// A copy: buttonClicked can rebuild the screen, which clears the live child list.
+		for (GuiEventListener child : new ArrayList<>(children())) {
+			if (!(child instanceof AbstractWidget guibutton))
+				continue;
 
 			if (guibutton.isMouseOver(mouseX, mouseY)) {
 				guibutton.playDownSound(this.minecraft.getSoundManager());

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/PalettePickerScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/PalettePickerScreen.java
@@ -32,7 +32,6 @@ import net.minecraft.client.gui.GuiGraphics;
 import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.Tooltip;
 import net.minecraft.client.gui.components.events.GuiEventListener;
 import net.minecraft.client.gui.screens.Screen;
 //? if >=1.21.10 {
@@ -306,8 +305,10 @@ public class PalettePickerScreen extends AbstractSimiScreen {
 			this.palette = palette;
 			visible = true;
 			active = true;
-			var tooltipText = Component.literal(palette.getName());
-			this.setTooltip(Tooltip.create(tooltipText));
+			// The mod's own tooltip, not vanilla's: vanilla shows a Tooltip when the widget is
+			// hovered *or* focused-by-keyboard, and these buttons became focusable when the screen
+			// started registering its widgets with vanilla. renderWindowForeground gates on hover.
+			setToolTip(Component.literal(palette.getName()));
 		}
 
 		//? if >=26 {

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/TextInputPromptScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/TextInputPromptScreen.java
@@ -68,9 +68,12 @@ public class TextInputPromptScreen extends AbstractSimiScreen {
 			McCompat.setScreen(minecraft, null);
 		}).pos(topLeftX + 100, topLeftY + 50).size(100, 20).build();
 
-		widgets.add(confirm);
-		widgets.add(abort);
-		widgets.add(nameField);
+		addWidget(confirm);
+		addWidget(abort);
+		// Registered last, and focused explicitly, so vanilla routes typing here and its own
+		// tab-forward pass at the end of init finds nothing after it to steal focus with.
+		addWidget(nameField);
+		setFocused(nameField);
 	}
 
 	@Override
@@ -112,26 +115,17 @@ public class TextInputPromptScreen extends AbstractSimiScreen {
 	public boolean keyPressed(KeyEvent event) {
 		if (event.key() == GLFW.GLFW_KEY_ENTER) {
 			confirm.onPress(null);
+			return true;
+		}
+		return super.keyPressed(event);
 	//?} else {
 	/*public boolean keyPressed(int keyCode, int p_keyPressed_2_, int p_keyPressed_3_) {
 		if (keyCode == GLFW.GLFW_KEY_ENTER) {
 			confirm.onPress();
+			return true;
+		}
+		return super.keyPressed(keyCode, p_keyPressed_2_, p_keyPressed_3_);
 	*///?}
-			return true;
-		}
-		//? if >=1.21.10 {
-		if (event.key() == 256 && this.shouldCloseOnEsc()) {
-		//?} else {
-		/*if (keyCode == 256 && this.shouldCloseOnEsc()) {
-		*///?}
-			this.onClose();
-			return true;
-		}
-		//? if >=1.21.10 {
-		return nameField.keyPressed(event);
-		//?} else {
-		/*return nameField.keyPressed(keyCode, p_keyPressed_2_, p_keyPressed_3_);
-		*///?}
 	}
 
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ThemeSettingsScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ThemeSettingsScreen.java
@@ -222,7 +222,10 @@ public class ThemeSettingsScreen extends AbstractSimiScreen {
 		//?} else {
 		/*if (button == 0) {*///?}
 			for (IconButton button2 : toggleButtons) {
-				if (button2.isHoveredOrFocused()) {
+				// Hover, not isHoveredOrFocused. These buttons are in children() now, so they can
+				// hold keyboard focus, and a focused button would otherwise fire on a click
+				// anywhere on the screen - including confirm, which closes and saves the theme.
+				if (button2.isHovered()) {
 					buttonClicked(button2);
 					return true;
 				}

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/ThemeSettingsScreen.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/ThemeSettingsScreen.java
@@ -197,15 +197,18 @@ public class ThemeSettingsScreen extends AbstractSimiScreen {
 				labelRoomHeight.setText(position + "m");
 				labelRoomHeight.setX(position > 9 ? topLeftX + 102 : topLeftX + 106);
 			});
-		widgets.add(areaRoomHeight);
-		widgets.add(labelRoomHeight);
+		addWidget(areaRoomHeight);
+		addWidget(labelRoomHeight);
 
 		confirm = new IconButton(topLeftX + 172, topLeftY + 157, ScreenResources.ICON_CONFIRM);
 		toggleButtons.add(confirm);
 
-		widgets.addAll(indicators);
-		widgets.addAll(inputs);
-		widgets.addAll(toggleButtons);
+		for (Indicator indicator : indicators)
+			addWidget(indicator);
+		for (EditBox input : inputs)
+			addWidget(input);
+		for (IconButton toggleButton : toggleButtons)
+			addWidget(toggleButton);
 	}
 
 	@Override

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Indicator.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Indicator.java
@@ -31,6 +31,8 @@ public class Indicator extends AbstractSimiWidget {
 
 	public Indicator(int x, int y, Component tooltip) {
 		super(x, y, ScreenResources.INDICATOR.width, ScreenResources.INDICATOR.height);
+		// A status light, not a control: inactive so it never consumes a click or a scroll.
+		active = false;
 		this.toolTip = ImmutableList.of(tooltip);
 		this.state = State.OFF;
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Label.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/gui/widgets/Label.java
@@ -32,6 +32,9 @@ public class Label extends AbstractSimiWidget {
 
 	public Label(int x, int y, Component text) {
 		super(x, y, Minecraft.getInstance().font.width(text), 10);
+		// Decoration only. Staying inactive keeps labels out of vanilla's getChildAt hit-testing,
+		// which matters because a label is usually drawn on top of the scroll input that writes it.
+		active = false;
 		font = Minecraft.getInstance().font;
 		this.text = Component.literal("Label");
 		color = 0xFFFFFF;

--- a/common/src/main/java/com/timmie/mightyarchitect/mixin/GameRendererAccessor.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/mixin/GameRendererAccessor.java
@@ -1,0 +1,33 @@
+package com.timmie.mightyarchitect.mixin;
+
+import net.minecraft.client.renderer.GameRenderer;
+//? if <1.21.4 {
+/*import net.minecraft.resources.ResourceLocation;
+*///?}
+import org.spongepowered.asm.mixin.Mixin;
+//? if <1.21.4 {
+/*import org.spongepowered.asm.mixin.gen.Invoker;
+*///?}
+
+/**
+ * Access to the post-effect loader on the versions that predate the {@code PostChainManager} API.
+ * <p>
+ * Before 1.21.4 the only way in is {@code GameRenderer.loadEffect(ResourceLocation)}, which is
+ * package-private up to 1.20.4 and private from 1.20.6. Reaching it by reflection does not work:
+ * a by-name lookup fails under any remapped runtime, and the fallback - scanning every declared
+ * method for a one-argument {@code ResourceLocation} method returning void - binds by shape, so it
+ * would silently pick a different method the moment one is added. An {@code @Invoker} is remapped
+ * by the annotation processor, so a rename becomes a load-time failure with a name in it instead
+ * of a shader that quietly never applies.
+ * <p>
+ * 1.21.4 renamed the method to {@code setPostEffect} and routed the mod through
+ * {@code PostChainManager}, so the accessor is guarded off there and this mixin applies nothing.
+ */
+@Mixin(GameRenderer.class)
+public interface GameRendererAccessor {
+
+	//? if <1.21.4 {
+	/*@Invoker("loadEffect")
+	void invokeLoadEffect(ResourceLocation location);
+	*///?}
+}

--- a/common/src/main/resources/mightyarchitect.mixins.json
+++ b/common/src/main/resources/mightyarchitect.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.timmie.mightyarchitect.mixin",
   "compatibilityLevel": "JAVA_${meta_java_range}",
   "client": [
+    "GameRendererAccessor",
     "GuiMixin",
     "KeyboardHandlerMixin",
     "MinecraftMixin",


### PR DESCRIPTION
## What this is

Three items from [`themightyarchitectury/code-audit`](../..), picked for **maintainability and stability** rather than user-visible impact. Each removes a recurring per-version cost rather than a one-off defect.

`main` @ `5cb414d`. No other guard-touching branch was in flight while this was written, per the project's own rule about concurrent edits to guarded files.

**Net: −330 lines, −31 guard markers**, and three failure modes that cannot recur.

| | before | after |
|---|---|---|
| `AbstractSimiScreen` | 230 lines, 61 guard markers | 185 lines, 33 |
| `HudTextBuffer` | 368 lines, 4 whole-file copies | 104 lines, 1 body |
| `Shaders` | 183 lines, 39 guard markers | 112 lines, 23 |

---

## P3.1 — `AbstractSimiScreen` → vanilla widget dispatch

**The problem.** The class kept its own `List<AbstractWidget>` and manually re-dispatched `render`, `mouseClicked`, `keyPressed`, `charTyped` and `mouseScrolled` — all of which vanilla `Screen` already does through `addWidget` / `children()`. That one decision meant hand-tracking five method signatures across seven years of Minecraft. The 1.21.10 `KeyEvent` / `MouseButtonEvent` / `CharacterEvent` rework cost ~10 new guard arms in this file alone, and that bill arrives again at the next input or render change.

**The fix.** Widgets register through `Screen.addWidget`, whose signature is byte-identical on all 13 supported versions (checked with `javap`). `children()` becomes the single widget list, and `ContainerEventHandler` owns clicks, keys, characters, scroll and focus. `mouseClicked`, `keyPressed` and `mouseScrolled` are deleted outright; `charTyped` survives only to close on the inventory letter, and now offers the character to the focused widget first so a text field can contain it.

**What stays, and why.** Drawing is still the mod's. `Screen.render` *also* calls `renderBackground` on **1.20.2, 1.20.4, 1.20.6 and 1.21.4** — and on no other supported version. Verified by disassembly:

```
=== 1.20.2   6: invokevirtual  // Method renderBackground:(Lnet/minecraft/client/gui/GuiGraphics;IIF)V
=== 1.21.1   (absent)
=== 1.21.4   6: invokevirtual  // Method renderBackground:(Lnet/minecraft/client/gui/GuiGraphics;IIF)V
=== 1.21.6   (absent)
```

So `super.render(...)` cannot be used to draw the widgets without double-darkening those four. One private `renderWidgets` carries the three draw-call epochs; that is the only widget code left in the mod that varies by version.

**`Label` and `Indicator` are now inactive**, because they are decoration. `AbstractWidget.isMouseOver` requires `active`, and `ContainerEventHandler.getChildAt` returns the *first* overlapping child — and a `Label` overlaps, and is registered *before*, the `ScrollInput` that writes to it in both `DesignExporterScreen` and `ThemeSettingsScreen`. Without this the labels would swallow the scroll.

**Two bugs fall out of the change:**

- `ThemeSettingsScreen`'s theme-name and author fields were **unusable**. `EditBox.charTyped` requires focus, focus is set by `ContainerEventHandler.mouseClicked`, and the mod bypassed that entirely — so nothing ever focused them. Vanilla click-to-focus now handles it.
- `ThemeSettingsScreen` never cleared its widget list, so a **window resize duplicated every widget**. Vanilla's `rebuildWidgets` calls `clearWidgets()` before `init()`.

`TextInputPromptScreen` registers its `EditBox` last and focuses it explicitly. That ordering is deliberate: from 1.20.6 `Screen.init` calls `setInitialFocus()` *after* `init()`, which tab-navigates forward from the focused element — with the field last there is nothing after it, so `nextFocusPath` returns null and the focus survives. Confirmed by disassembling `Screen.init` and `Screen.setInitialFocus` on 1.20.6, 1.21.10, 1.21.11, 26.1 and 26.2.

---

## P3.2 — `HudTextBuffer` is one body, not four

300 lines of near-identical logic in **four whole-file guarded copies**. This is precisely the failure the project has already shipped once: #34 fixed two `HudTextBuffer` arms while #32 concurrently added two more carrying the old constant, and git reports no conflict, because a change inside one guard arm is not a change in the others.

Only three things actually differed — the graphics type, the camera view rotation, and the text call. Those are now `McCompat.viewRotation` and `McCompat.drawText`, and the projection maths exists once. **368 → 104 lines.**

---

## P3.7 — reflection against obfuscated Minecraft → accessor mixin

Below 1.21.4 the mod loaded its post chain by reflecting on `GameRenderer`: first by name, which fails under any remapped runtime, then by **scanning every declared method for a one-argument `ResourceLocation` method returning void**.

That binds by *shape*. `javap -p` across the matrix shows it currently matches exactly one method per version, so it works — by luck:

```
1.19.4 … 1.20.4   void loadEffect(ResourceLocation)          (package-private)
1.20.6, 1.21.1    private void loadEffect(ResourceLocation)
1.21.4+           private void setPostEffect(ResourceLocation)   ← renamed
```

The first time Mojang adds another such method, the scan silently binds the wrong one and the only symptom is a shader that never appears. An `@Invoker` is remapped by the annotation processor, so the same event becomes a load-time failure that names the method. The accessor is guarded to `<1.21.4`; above that the mod goes through `PostChainManager`.

`Shaders.java` was also restructured so each guarded arm is a whole method. It previously interleaved two eras' method bodies across **shared closing braces** — the `<1.21.4` and `>=1.21.4` arms were brace-balanced only by coincidence of counting, which is not a property anyone should have to re-derive to make a change. Its two byte-identical `>=26` / `>=1.21.11` arms are merged, and the unused `getLocation()` is dropped.

---

## Input dispatch coverage (second commit)

Moving five input paths onto vanilla dispatch while **nothing in any matrix clicked, typed or scrolled** was the real hole in the first commit: a screen whose widgets are never registered draws perfectly and silently ignores the mouse, so the existing screenshot checks would have stayed green with every control dead.

The client matrix now runs **40 checks per target, up from 27**:

- two included-palette buttons clicked **by position**, and the selection must follow — registration, dispatch and hit-testing in one assertion
- the text prompt typed into and the characters read back from the field on close — the check that settles *"does vanilla's own `setInitialFocus` pass steal focus from the field?"* by experiment rather than by disassembly
- hit-test routing over a scroll input must resolve to it and **not** to the label drawn on top of it, and every label/indicator must be present and inactive

**Writing them found a defect in the first commit.** Widgets are focusable now that they are registered with vanilla, and from 1.20.6 `Screen.init` calls `setInitialFocus()` *after* `init()`. `renderWindowForeground` drew a tooltip for anything hovered **or focused** — harmless when `children()` was always empty, but it leaves a tooltip permanently on screen now that it is not. It keys off hover alone.

Two notes for whoever writes the next test of this kind. **Scroll cannot be synthesised**: `ScrollInput` gates on the hover flag `AbstractWidget.render` computes from the *real* cursor, so a synthesised scroll where the cursor is not pointing is refused by the widget itself, for reasons unrelated to dispatch — assert `ContainerEventHandler.getChildAt(x, y)`, which *is* the routing decision and is identical on all 13 versions. And **the decoration check nearly shipped vacuous**: "every decorative widget is inactive" was first written against the palette picker, which has no labels.

`foundation/compat/ScreenInput` carries the two input signatures the test synthesises, because the companion mod is not Stonecutter-processed and cannot name them itself. It is short only because the screens stopped re-dispatching input.

---

## Validation

- **`./gradlew compileAll` — BUILD SUCCESSFUL.** 13 Fabric nodes + 2 Forge nodes + 10 NeoForge nodes, `main` plus both test companions.
- **Every API was `javap`'d against the actual cached Minecraft jar for all 13 versions before any code was written**, per the CI-first workflow. That is what caught the `renderBackground`-inside-`render` split, the `renderables`-is-private constraint, the `getChildAt` first-match hazard, and the `loadEffect` → `setPostEffect` rename.
- **Guard sweep:** every arm of every touched file was read back from Stonecutter's generated output for 1.19.4, 1.20.1, 1.20.2, 1.21.1, 1.21.10, 1.21.11 and 26.x, not just the active version.
- **CI covers all four directly.** The client matrix clicks, types and hit-tests the screens (P3.1), asserts `Shaders.Blueprint.isActive()` and a blue-bias shift (P3.7), and screenshot-diffs the world-space labels (P3.2), on every target.
- **Mutation-tested:** emptying the widget render loop turned all 13 versions red on `CAPTURE_PALETTE_PREVIEW`. Details in the comments.
- **Rebased onto `b773c62`** (PR #35) with zero file overlap; the replayed change is byte-identical.

## Deliberately not in scope

- **The hardcoded `'e'` close key.** The audit is right that it ignores the player's keybind, but reading the bound key portably needs another accessor (`KeyMapping.key` is private with no Fabric-side getter), and this PR is about removing version-sensitive code, not adding it. Behaviour is unchanged; it belongs with the config/keybind work.
- **`PostChainManager` is a fifth whole-file guarded duplicate** (four `public class PostChainManager` declarations in one file) that the audit does not list. Same bug class as P3.2 and worth its own pass.

