### PR TITLE
Fix every P1 correctness bug in the de-port audit

### DIFF
--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -11,6 +11,7 @@ import com.timmie.mightyarchitect.AllItems;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.control.ArchitectManager;
+import com.timmie.mightyarchitect.control.compose.Cuboid;
 import com.timmie.mightyarchitect.control.design.DesignTheme;
 import com.timmie.mightyarchitect.control.design.DesignExporter;
 import com.timmie.mightyarchitect.control.design.Sketch;
@@ -40,7 +41,11 @@ import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
@@ -311,6 +316,8 @@ public final class ClientTestController {
         check(palette.get(Palette.ROOF_PRIMARY).equals(roundTrip.get(Palette.ROOF_PRIMARY)),
             "palette NBT block state round-tripped");
 
+        checkDataIntegrityFixes();
+
         // WrappedWorld overrides methods NeoForge adds to Level that vanilla does not have. Those
         // resolve when the class is verified, so a wrong override is an AbstractMethodError the
         // moment the class first loads — which the build matrix cannot catch. It is client-only
@@ -321,6 +328,54 @@ public final class ClientTestController {
             "WrappedWorld loads and delegates to the wrapped level");
 
         advance(Stage.CAPTURE_BASELINE);
+    }
+
+    /**
+     * Guards the correctness fixes whose only symptom was lost user work: a design filename that
+     * was a Java object dump, a theme whose palette was the shared global default, a theme file
+     * whose one unknown layer name emptied the whole theme list.
+     * <p>
+     * This is pure logic that wants a unit test, but the mod has no JUnit suite yet, and an
+     * assertion that runs on all 25 targets beats one that runs nowhere.
+     */
+    private static void checkDataIntegrityFixes() {
+        check("my_design.json".equals(DesignExporter.designFilename("My Design")),
+            "design filename derived from sign text");
+        check("my_design.json".equals(DesignExporter.designFilename("my_design.json")),
+            "design filename is stable when the sign already carries it");
+        check(DesignExporter.designFilename("   ").isEmpty(),
+            "blank sign text falls back to an indexed design filename");
+        check(!DesignExporter.designFilename("../../evil name").contains("/")
+            && !DesignExporter.designFilename("../../evil name").contains(".."),
+            "design filename cannot escape its folder");
+
+        PaletteDefinition sharedDefault = PaletteDefinition.defaultPalette();
+        BlockState before = sharedDefault.get(Palette.ROOF_PRIMARY);
+        DesignTheme created = ThemeStorage.createTheme("Client Test Theme");
+        check(created.getDefaultPalette() != sharedDefault
+            && created.getDefaultPalette() != created.getDefaultSecondaryPalette(),
+            "new themes get their own palettes");
+        created.getDefaultPalette().put(Palette.ROOF_PRIMARY, Blocks.GOLD_BLOCK);
+        check(sharedDefault.get(Palette.ROOF_PRIMARY).equals(before),
+            "editing a theme palette leaves the default palette alone");
+        check(!created.getFilePath().isEmpty() && !created.getFilePath().contains("/"),
+            "theme file path is a single sanitized folder name");
+
+        ListTag layers = new ListTag();
+        layers.add(StringTag.valueOf("Regular"));
+        layers.add(StringTag.valueOf("NotALayerThisBuildKnows"));
+        CompoundTag themeTag = new CompoundTag();
+        themeTag.putString("Name", "Client Test Theme");
+        themeTag.putString("Designer", "client-test");
+        themeTag.put("Layers", layers);
+        themeTag.put("Types", new ListTag());
+        DesignTheme lenient = DesignTheme.fromNBT(themeTag);
+        check(lenient != null && lenient.getLayers().size() == 1,
+            "an unknown layer name is skipped instead of throwing");
+
+        BlockPos origin = new BlockPos(4, 5, 6);
+        check(new Cuboid(origin, 1, 2, 3).hashCode() == new Cuboid(origin, 1, 2, 3).hashCode(),
+            "equal cuboids hash equally");
     }
 
     private static void captureBaseline(Minecraft minecraft) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/compose/Cuboid.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/compose/Cuboid.java
@@ -109,6 +109,25 @@ public class Cuboid {
 		return obj instanceof Cuboid && ((Cuboid) obj).getOrigin().equals(getOrigin())
 				&& ((Cuboid) obj).getSize().equals(getSize());
 	}
+
+	/**
+	 * Matches {@link #equals(Object)}, which it has to: two equal objects with different hashes
+	 * break every hash-based collection they are put in.
+	 * <p>
+	 * Note that a Cuboid is mutable and moved in place by the planner tools, so its hash changes
+	 * with it. Anything keying a map on one is therefore keyed on identity - see
+	 * {@link com.timmie.mightyarchitect.control.design.DesignPicker}.
+	 */
+	@Override
+	public int hashCode() {
+		int hash = x;
+		hash = 31 * hash + y;
+		hash = 31 * hash + z;
+		hash = 31 * hash + width;
+		hash = 31 * hash + height;
+		hash = 31 * hash + length;
+		return hash;
+	}
 	
 	public BoundingBox toMBB() {
 		return BoundingBox.fromCorners(getOrigin(), getOrigin().offset(getSize()));

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignExporter.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignExporter.java
@@ -29,10 +29,15 @@ import net.minecraft.world.level.block.state.BlockState;
 
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Locale;
 
 public class DesignExporter {
 
-	public static PaletteDefinition scanningPalette = PaletteDefinition.defaultPalette();
+	// A clone, not defaultPalette() itself: the scanning palette is edited in place by the theme
+	// editor, and handing out the shared default would let that edit rewrite the palette every
+	// other theme starts from.
+	public static PaletteDefinition scanningPalette = PaletteDefinition.defaultPalette()
+		.clone();
 
 	public static DesignTheme theme;
 	public static DesignType type;
@@ -199,16 +204,16 @@ public class DesignExporter {
 
 		BlockPos signPos = anchor.above();
 		if (worldIn.getBlockState(signPos)
-			.getBlock() == Blocks.SPRUCE_SIGN) {
-			SignBlockEntity sign = (SignBlockEntity) worldIn.getBlockEntity(signPos);
+			.getBlock() == Blocks.SPRUCE_SIGN && worldIn.getBlockEntity(signPos) instanceof SignBlockEntity sign) {
 			//? if >=1.20 {
-			filename = sign.getFrontText().toString();
+			String signedName = sign.getFrontText().getMessage(1, false).getString();
 			//?} else {
-			/*filename = sign.getMessage(1, false).getString();
+			/*String signedName = sign.getMessage(1, false).getString();
 			*///?}
-			designPath = typePath + "/" + filename;
+			filename = designFilename(signedName);
+		}
 
-		} else {
+		if (filename.isEmpty()) {
 			int index = 0;
 			while (index < 2048) {
 				filename = "design" + ((index == 0) ? "" : "_" + index) + ".json";
@@ -218,6 +223,8 @@ public class DesignExporter {
 					break;
 				index++;
 			}
+		} else {
+			designPath = typePath + "/" + filename;
 		}
 
 		AllPackets.sendToServer(new PlaceSignPacket(layer.getDisplayName()
@@ -226,6 +233,26 @@ public class DesignExporter {
 		return designPath;
 		//
 
+	}
+
+	/**
+	 * Turns the name written on line two of a design's sign into the file that design is saved as.
+	 * <p>
+	 * The name is echoed back onto the sign after every export, so this has to be idempotent: an
+	 * already-suffixed name keeps its single {@code .json} instead of growing another one, which is
+	 * what makes re-exporting overwrite the previous file rather than leaving an orphan behind that
+	 * keeps loading forever.
+	 *
+	 * @return the filename, or empty when the sign carries no usable name
+	 */
+	public static String designFilename(String signedName) {
+		String base = signedName.trim();
+		if (base.toLowerCase(Locale.ROOT)
+			.endsWith(".json"))
+			base = base.substring(0, base.length() - ".json".length());
+
+		String slug = FilesHelper.slug(base);
+		return slug.isEmpty() ? "" : slug + ".json";
 	}
 
 	public static void setTheme(DesignTheme theme) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignPicker.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignPicker.java
@@ -8,7 +8,7 @@ import com.timmie.mightyarchitect.control.design.partials.Design;
 import com.timmie.mightyarchitect.control.design.partials.Design.DesignInstance;
 import com.timmie.mightyarchitect.foundation.utility.DesignHelper;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -19,8 +19,13 @@ public class DesignPicker {
 	private Map<Stack, Design> roofDesigns;
 
 	public DesignPicker() {
-		roomDesigns = new HashMap<>();
-		roofDesigns = new HashMap<>();
+		// Identity maps. Rooms are Cuboids: mutable, and moved and resized in place by the planner
+		// tools, so a value-based hash would strand a room's cached design the moment it is
+		// dragged. The keys are the live objects from the ground plan, and identity is what these
+		// caches have always actually meant - it was only implicit before, in a Cuboid that
+		// overrode equals but not hashCode.
+		roomDesigns = new IdentityHashMap<>();
+		roofDesigns = new IdentityHashMap<>();
 	}
 
 	public void reset() {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignResourceLoader.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignResourceLoader.java
@@ -44,7 +44,13 @@ public class DesignResourceLoader {
 
 		});
 
-		designMap.putAll(loadExternalDesignsForTheme(theme)); // extensions
+		// Merged per design set, not per layer. putAll replaces whole layers, so as soon as a
+		// folder existed under themes/<builtin>/ - which exporting a single design creates - every
+		// built-in design in that layer disappeared behind the handful of exported ones.
+		loadExternalDesignsForTheme(theme).forEach((layer, typeMap) -> typeMap.forEach((type, designs) -> designMap
+			.computeIfAbsent(layer, missingLayer -> new HashMap<>())
+			.computeIfAbsent(type, missingType -> new HashSet<>())
+			.addAll(designs)));
 
 		return designMap;
 	}
@@ -75,24 +81,27 @@ public class DesignResourceLoader {
 	private static Map<DesignLayer, Map<DesignType, Set<CompoundTag>>> loadThemeFromThemeFile(DesignTheme theme) {
 		final Map<DesignLayer, Map<DesignType, Set<CompoundTag>>> compoundMap = new HashMap<>();
 
-		CompoundTag importedThemeFile = new CompoundTag();
+		CompoundTag importedThemeFile = null;
 
 		if (theme.getFilePath().endsWith(".theme")) {
-			try {
-				InputStream inputStream = Files.newInputStream(Paths.get("themes/" + theme.getFilePath()),
-						StandardOpenOption.READ);
+			try (InputStream inputStream = Files.newInputStream(Paths.get("themes/" + theme.getFilePath()),
+					StandardOpenOption.READ)) {
 				//? if >=1.20.3 {
 				importedThemeFile = NbtIo.readCompressed(inputStream, NbtAccounter.unlimitedHeap());
 				//?} else {
 				/*importedThemeFile = NbtIo.readCompressed(inputStream);
 				*///?}
-				inputStream.close();
 			} catch (IOException e) {
-				e.printStackTrace();
+				TheMightyArchitect.logger.error("Could not read theme " + theme.getFilePath(), e);
 			}
 		} else {
 			importedThemeFile = FilesHelper.loadJsonAsNBT("themes/" + theme.getFilePath());
 		}
+
+		// A missing or malformed theme file yields no designs rather than an NPE that takes the
+		// whole theme list down with it.
+		if (importedThemeFile == null)
+			return compoundMap;
 
 		final CompoundTag themeFile = importedThemeFile;
 
@@ -168,7 +177,8 @@ public class DesignResourceLoader {
 			if (TheMightyArchitect.class.getClassLoader().getResource(path) == null)
 				break;
 			final CompoundTag designTag = FilesHelper.loadJsonResourceAsNBT(path);
-			designs.add(type.getDesign().fromNBT(designTag));
+			if (designTag != null)
+				designs.add(type.getDesign().fromNBT(designTag));
 			index++;
 		}
 
@@ -182,15 +192,14 @@ public class DesignResourceLoader {
 		if (!Files.exists(Paths.get(folderPath)))
 			return designs;
 
-		try {
-			DirectoryStream<Path> newDirectoryStream = Files.newDirectoryStream(Paths.get(folderPath));
-			for (Path path : newDirectoryStream) {
+		try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(folderPath))) {
+			for (Path path : directoryStream) {
 				final CompoundTag designTag = FilesHelper.loadJsonAsNBT(path.toString());
-				designs.add(designTag);
+				if (designTag != null)
+					designs.add(designTag);
 			}
-			newDirectoryStream.close();
 		} catch (IOException e) {
-			e.printStackTrace();
+			TheMightyArchitect.logger.error("Could not list designs in " + folderPath, e);
 		}
 
 		return designs;

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignTheme.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/DesignTheme.java
@@ -1,11 +1,13 @@
 package com.timmie.mightyarchitect.control.design;
 
 import com.google.common.collect.ImmutableList;
+import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.control.design.partials.Design;
 import com.timmie.mightyarchitect.control.palette.PaletteDefinition;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
+import net.minecraft.nbt.Tag;
 
 import java.util.*;
 
@@ -186,15 +188,44 @@ public class DesignTheme {
 			*///?}
 
 		//? if >=1.21.6 {
-		compound.getList("Layers").orElse(new ListTag()).forEach(s -> theme.layers.add(DesignLayer.valueOf(((StringTag) s).value())));
-		compound.getList("Types").orElse(new ListTag()).forEach(s -> theme.types.add(DesignType.valueOf(((StringTag) s).value())));
+		ListTag layerTags = compound.getList("Layers").orElse(new ListTag());
+		ListTag typeTags = compound.getList("Types").orElse(new ListTag());
 		//?} else {
-		/*compound.getList("Layers", 8).forEach(s -> theme.layers.add(DesignLayer.valueOf(((StringTag) s).getAsString())));
-		compound.getList("Types", 8).forEach(s -> theme.types.add(DesignType.valueOf(((StringTag) s).getAsString())));
+		/*ListTag layerTags = compound.getList("Layers", 8);
+		ListTag typeTags = compound.getList("Types", 8);
 		*///?}
+
+		layerTags.forEach(s -> addIfKnown(theme.layers, DesignLayer.class, stringValue(s)));
+		typeTags.forEach(s -> addIfKnown(theme.types, DesignType.class, stringValue(s)));
 
 		theme.updateRoomLayers();
 		return theme;
+	}
+
+	//? if >=1.21.6 {
+	private static String stringValue(Tag tag) {
+		return tag instanceof StringTag string ? string.value() : "";
+	}
+	//?} else {
+	/*private static String stringValue(Tag tag) {
+		return tag instanceof StringTag string ? string.getAsString() : "";
+	}
+	*///?}
+
+	/**
+	 * Adds an enum constant by name, skipping it if no such constant exists.
+	 * <p>
+	 * A theme written by a newer version of the mod, or simply by hand, can name a layer or type
+	 * this build does not have. {@code valueOf} threw for it, and the throw escaped the single
+	 * try block around the whole theme directory scan - so one such file emptied the theme list
+	 * instead of costing that theme one layer.
+	 */
+	private static <E extends Enum<E>> void addIfKnown(List<E> target, Class<E> type, String name) {
+		try {
+			target.add(Enum.valueOf(type, name));
+		} catch (IllegalArgumentException unknown) {
+			TheMightyArchitect.logger.warn("Ignoring unknown {} '{}' in a theme", type.getSimpleName(), name);
+		}
 	}
 
 	public void setImported(boolean imported) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/RoomDesignCache.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/RoomDesignCache.java
@@ -4,15 +4,16 @@ import com.timmie.mightyarchitect.control.compose.Room;
 import com.timmie.mightyarchitect.control.compose.Stack;
 import com.timmie.mightyarchitect.control.design.partials.Design;
 
-import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 
 public class RoomDesignCache {
 	
 	private Map<Room, Design> cachedDesigns;
-	
+
 	public RoomDesignCache() {
-		cachedDesigns = new HashMap<>();
+		// Identity, for the same reason as DesignPicker: Room is a mutable Cuboid.
+		cachedDesigns = new IdentityHashMap<>();
 	}
 
 	public void rerollAll() {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
@@ -1,5 +1,6 @@
 package com.timmie.mightyarchitect.control.design;
 
+import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.control.palette.PaletteDefinition;
 import com.timmie.mightyarchitect.foundation.utility.FilesHelper;
 import net.minecraft.client.Minecraft;
@@ -81,10 +82,14 @@ public class ThemeStorage {
 			name = "My Theme";
 		DesignTheme theme = new DesignTheme(name, Minecraft.getInstance().player.getName()
 			.getString());
-		theme.setFilePath(FilesHelper.slug(name));
+		theme.setFilePath(FilesHelper.slugOr(name, "my_theme"));
 		theme.setImported(true);
-		theme.setDefaultPalette(PaletteDefinition.defaultPalette());
-		theme.setDefaultSecondaryPalette(PaletteDefinition.defaultPalette());
+		// Clones: storing defaultPalette() itself handed the palette editor the shared default, so
+		// recolouring one theme recoloured the starting palette of every theme made afterwards.
+		theme.setDefaultPalette(PaletteDefinition.defaultPalette()
+			.clone());
+		theme.setDefaultSecondaryPalette(PaletteDefinition.defaultPalette()
+			.clone());
 		return theme.withLayers(DesignLayer.Regular, DesignLayer.Roofing, DesignLayer.Foundation)
 			.withTypes(DesignType.WALL, DesignType.CORNER, DesignType.ROOF, DesignType.FACADE, DesignType.FLAT_ROOF);
 	}
@@ -162,6 +167,8 @@ public class ThemeStorage {
 		CompoundTag paletteCompound = FilesHelper.loadJsonResourceAsNBT("themes/" + themeFolder + "/palette.json");
 		CompoundTag palette2Compound = FilesHelper.loadJsonResourceAsNBT("themes/" + themeFolder + "/palette2.json");
 		DesignTheme theme = DesignTheme.fromNBT(themeCompound);
+		if (theme == null)
+			throw new IllegalStateException("Built-in theme " + themeFolder + " is missing from the mod jar");
 		theme.setFilePath(themeFolder);
 		theme.setImported(false);
 		theme.setDefaultPalette(PaletteDefinition.fromNBT(paletteCompound));
@@ -174,84 +181,94 @@ public class ThemeStorage {
 		createdThemes = new ArrayList<>();
 		String folderPath = "themes";
 
-		try {
-			if (!Files.isDirectory(Paths.get(folderPath)))
-				Files.createDirectory(Paths.get(folderPath));
+		FilesHelper.createFolderIfMissing(folderPath);
 
-			DirectoryStream<Path> newDirectoryStream = Files.newDirectoryStream(Paths.get(folderPath));
-			for (Path path : newDirectoryStream) {
+		try (DirectoryStream<Path> directoryStream = Files.newDirectoryStream(Paths.get(folderPath))) {
+			for (Path path : directoryStream) {
 				String themeFolder = path.getFileName()
 					.toString();
-
-				CompoundTag themeCompound;
-				CompoundTag paletteCompound;
-				CompoundTag secondaryPaletteCompound = null;
 
 				if (themeFolder.equals("export"))
 					continue;
 
-				if (themeFolder.endsWith(".theme") || themeFolder.endsWith(".json")) {
-					CompoundTag themeFile = new CompoundTag();
-
-					if (themeFolder.endsWith(".theme")) {
-						try {
-							InputStream inputStream = Files.newInputStream(Paths.get(folderPath + "/" + themeFolder),
-								StandardOpenOption.READ);
-							//? if >=1.20.3 {
-							themeFile = NbtIo.readCompressed(inputStream, NbtAccounter.unlimitedHeap());
-							//?} else {
-							/*themeFile = NbtIo.readCompressed(inputStream);
-							*///?}
-							inputStream.close();
-						} catch (IOException e) {
-							e.printStackTrace();
-						}
-					} else {
-						themeFile = FilesHelper.loadJsonAsNBT("themes/" + themeFolder);
-					}
-
-					//? if >=1.21.6 {
-					themeCompound = themeFile.getCompound("Theme").orElse(new CompoundTag());
-					//?} else {
-					/*themeCompound = themeFile.getCompound("Theme");*///?}
-					//? if >=1.21.6 {
-					paletteCompound = themeFile.getCompound("Palette").orElse(new CompoundTag());
-					//?} else {
-					/*paletteCompound = themeFile.getCompound("Palette");*///?}
-					if (themeFile.contains("SecondaryPalette"))
-						//? if >=1.21.6 {
-						secondaryPaletteCompound = themeFile.getCompound("SecondaryPalette").orElse(new CompoundTag());
-						//?} else {
-						/*secondaryPaletteCompound = themeFile.getCompound("SecondaryPalette");*///?}
-
-				} else {
-					themeCompound = FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder + "/theme.json");
-					paletteCompound = FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder + "/palette.json");
-					secondaryPaletteCompound =
-						FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder + "/palette2.json");
+				// Per theme, not per scan: an unknown layer name or a malformed file used to throw
+				// out of the loop and drop every theme after it from the list.
+				try {
+					importTheme(folderPath, themeFolder);
+				} catch (RuntimeException e) {
+					TheMightyArchitect.logger.error("Skipping unreadable theme " + themeFolder, e);
 				}
-
-				if (themeCompound == null)
-					continue;
-
-				DesignTheme theme = DesignTheme.fromNBT(themeCompound);
-				theme.setFilePath(themeFolder);
-				theme.setImported(true);
-				theme.setDefaultPalette(PaletteDefinition.fromNBT(paletteCompound));
-
-				if (secondaryPaletteCompound != null)
-					theme.setDefaultSecondaryPalette(PaletteDefinition.fromNBT(secondaryPaletteCompound));
-				else
-					theme.setDefaultSecondaryPalette(theme.getDefaultPalette());
-
-				importedThemes.add(theme);
-				if (!themeFolder.endsWith(".theme") && !themeFolder.endsWith(".json"))
-					createdThemes.add(theme);
 			}
-			newDirectoryStream.close();
 		} catch (IOException e) {
-			e.printStackTrace();
+			TheMightyArchitect.logger.error("Could not list themes in " + folderPath, e);
+		}
+	}
+
+	private static void importTheme(String folderPath, String themeFolder) {
+		CompoundTag themeCompound;
+		CompoundTag paletteCompound;
+		CompoundTag secondaryPaletteCompound = null;
+
+		boolean packedIntoOneFile = themeFolder.endsWith(".theme") || themeFolder.endsWith(".json");
+
+		if (packedIntoOneFile) {
+			CompoundTag themeFile = themeFolder.endsWith(".theme")
+				? readCompressedTheme(folderPath + "/" + themeFolder)
+				: FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder);
+
+			if (themeFile == null)
+				return;
+
+			//? if >=1.21.6 {
+			themeCompound = themeFile.getCompound("Theme").orElse(new CompoundTag());
+			//?} else {
+			/*themeCompound = themeFile.getCompound("Theme");*///?}
+			//? if >=1.21.6 {
+			paletteCompound = themeFile.getCompound("Palette").orElse(new CompoundTag());
+			//?} else {
+			/*paletteCompound = themeFile.getCompound("Palette");*///?}
+			if (themeFile.contains("SecondaryPalette"))
+				//? if >=1.21.6 {
+				secondaryPaletteCompound = themeFile.getCompound("SecondaryPalette").orElse(new CompoundTag());
+				//?} else {
+				/*secondaryPaletteCompound = themeFile.getCompound("SecondaryPalette");*///?}
+
+		} else {
+			themeCompound = FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder + "/theme.json");
+			paletteCompound = FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder + "/palette.json");
+			secondaryPaletteCompound = FilesHelper.loadJsonAsNBT(folderPath + "/" + themeFolder + "/palette2.json");
 		}
 
+		if (themeCompound == null)
+			return;
+
+		DesignTheme theme = DesignTheme.fromNBT(themeCompound);
+		theme.setFilePath(themeFolder);
+		theme.setImported(true);
+		theme.setDefaultPalette(PaletteDefinition.fromNBT(paletteCompound));
+
+		if (secondaryPaletteCompound != null)
+			theme.setDefaultSecondaryPalette(PaletteDefinition.fromNBT(secondaryPaletteCompound));
+		else
+			// Cloned, so that editing the secondary palette does not also edit the primary one.
+			theme.setDefaultSecondaryPalette(theme.getDefaultPalette()
+				.clone());
+
+		importedThemes.add(theme);
+		if (!packedIntoOneFile)
+			createdThemes.add(theme);
+	}
+
+	private static CompoundTag readCompressedTheme(String path) {
+		try (InputStream inputStream = Files.newInputStream(Paths.get(path), StandardOpenOption.READ)) {
+			//? if >=1.20.3 {
+			return NbtIo.readCompressed(inputStream, NbtAccounter.unlimitedHeap());
+			//?} else {
+			/*return NbtIo.readCompressed(inputStream);
+			*///?}
+		} catch (IOException e) {
+			TheMightyArchitect.logger.error("Could not read theme " + path, e);
+			return null;
+		}
 	}
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/control/palette/PaletteDefinition.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/palette/PaletteDefinition.java
@@ -1,9 +1,9 @@
 package com.timmie.mightyarchitect.control.palette;
 
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Direction.Axis;
-import net.minecraft.core.registries.Registries;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtUtils;
 import net.minecraft.world.level.block.Block;
@@ -29,6 +29,13 @@ public class PaletteDefinition {
 	private BlockState clear;
 	private static PaletteDefinition defaultPalette;
 
+	/**
+	 * The palette every other one starts from.
+	 * <p>
+	 * This is a single shared instance and {@link PaletteDefinition} is mutable, so anything that
+	 * stores it, hands it to the palette editor or exports it must {@link #clone()} first -
+	 * otherwise editing one theme's palette silently rewrites the default for all of them.
+	 */
 	public static PaletteDefinition defaultPalette() {
 		if (defaultPalette == null) {
 			defaultPalette = new PaletteDefinition("Standard Palette");
@@ -130,7 +137,14 @@ public class PaletteDefinition {
 	public static PaletteDefinition fromNBT(CompoundTag compound) {
 		PaletteDefinition palette = defaultPalette().clone();
 
-		var holderGetter = Minecraft.getInstance().level.holderLookup(Registries.BLOCK);
+		// Blocks live in the built-in registry on both sides, so this deliberately does not go
+		// through Minecraft.getInstance().level: reading it there NPE'd whenever a palette was
+		// loaded outside a world, which is why palette loading had to be deferred until joining.
+		//? if >=1.21.4 {
+		HolderGetter<Block> holderGetter = BuiltInRegistries.BLOCK;
+		//?} else {
+		/*HolderGetter<Block> holderGetter = BuiltInRegistries.BLOCK.asLookup();
+		*///?}
 
 		if (compound != null) {
 			if (compound.contains("Palette")) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/palette/PaletteStorage.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/palette/PaletteStorage.java
@@ -3,10 +3,6 @@ package com.timmie.mightyarchitect.control.palette;
 import com.google.gson.JsonElement;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
-//? if >=1.21.6 {
-//?} else {
-/*import com.mojang.brigadier.exceptions.CommandSyntaxException;
-*///?}
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.foundation.utility.FilesHelper;
 import net.minecraft.nbt.CompoundTag;
@@ -18,6 +14,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Stream;
 
 public class PaletteStorage {
 
@@ -63,18 +60,18 @@ public class PaletteStorage {
 	}
 
 	public static PaletteDefinition importPalette(Path path) {
-		try {
-			JsonReader reader = new JsonReader(Files.newBufferedReader(path));
+		try (JsonReader reader = new JsonReader(Files.newBufferedReader(path))) {
 			reader.setLenient(true);
 			JsonElement element = Streams.parse(reader);
 			//? if >=1.21.6 {
 			return PaletteDefinition.fromNBT(TagParser.create(net.minecraft.nbt.NbtOps.INSTANCE).parseCompoundFully(element.toString()));
-		} catch (Exception e) {
 			//?} else {
 			/*return PaletteDefinition.fromNBT(TagParser.parseTag(element.toString()));
-		} catch (IOException | CommandSyntaxException e) {
 			*///?}
-			e.printStackTrace();
+		} catch (Exception e) {
+			// Exception rather than the exact types: the parser throws a checked
+			// CommandSyntaxException before 1.21.6 and an unchecked parse error after it.
+			TheMightyArchitect.logger.error("Could not read palette " + path, e);
 		}
 		return null;
 	}
@@ -83,17 +80,20 @@ public class PaletteStorage {
 		palettes = new HashMap<>();
 		resourcePalettes = new HashMap<>();
 		loadResourcePalettes();
-		try {
-			Files.list(Paths.get("palettes/")).forEach(path -> loadPalette(path));
+		try (Stream<Path> files = Files.list(Paths.get("palettes/"))) {
+			files.forEach(PaletteStorage::loadPalette);
 		} catch (NoSuchFileException e) {
 			// No palettes created yet
 		} catch (IOException e) {
-			e.printStackTrace();
+			TheMightyArchitect.logger.error("Could not list palettes", e);
 		}
 	}
 
 	public static void loadPalette(Path path) {
 		PaletteDefinition palette = importPalette(path);
+		// One unreadable palette file used to NPE here and abort loading all the others.
+		if (palette == null)
+			return;
 		palettes.put(palette.getName(), palette);
 	}
 
@@ -104,8 +104,10 @@ public class PaletteStorage {
 			if (TheMightyArchitect.class.getClassLoader().getResource(path) == null)
 				break;
 			CompoundTag tag = FilesHelper.loadJsonResourceAsNBT(path);
-			PaletteDefinition paletteDefinition = PaletteDefinition.fromNBT(tag);
-			resourcePalettes.put(paletteDefinition.getName(), paletteDefinition);
+			if (tag != null) {
+				PaletteDefinition paletteDefinition = PaletteDefinition.fromNBT(tag);
+				resourcePalettes.put(paletteDefinition.getName(), paletteDefinition);
+			}
 			index++;
 		}
 	}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperByteBufferCache.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperByteBufferCache.java
@@ -16,6 +16,7 @@ import com.mojang.blaze3d.vertex.MeshData;
 *///?}
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexFormat;
+import com.timmie.mightyarchitect.TheMightyArchitect;
 import net.minecraft.client.Minecraft;
 //? if >=26 {
 import net.minecraft.client.renderer.block.BlockAndTintGetter;
@@ -86,8 +87,10 @@ public class SuperByteBufferCache {
 		try {
 			return compartmentCache.get(key, supplier::get);
 		} catch (ExecutionException e) {
-			e.printStackTrace();
-			return null;
+			// An empty buffer, not null: this feeds straight into the render path, where a null
+			// turns one failed block model into a crash for the whole frame.
+			TheMightyArchitect.logger.error("Could not build a buffer for " + key, e);
+			return SuperByteBuffer.empty();
 		}
 	}
 

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/FilesHelper.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/FilesHelper.java
@@ -5,10 +5,6 @@ import com.google.gson.JsonParser;
 import com.google.gson.internal.Streams;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-//? if >=1.21.6 {
-//?} else {
-/*import com.mojang.brigadier.exceptions.CommandSyntaxException;
-*///?}
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.TagParser;
@@ -27,15 +23,25 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Locale;
+import java.util.Set;
 
 public class FilesHelper {
+
+	/** Names Windows refuses as a file, with or without an extension. */
+	private static final Set<String> RESERVED_NAMES = Set.of("con", "prn", "aux", "nul", "com1", "com2", "com3",
+		"com4", "com5", "com6", "com7", "com8", "com9", "lpt1", "lpt2", "lpt3", "lpt4", "lpt5", "lpt6", "lpt7",
+		"lpt8", "lpt9");
 
 	public static void createFolderIfMissing(String name) {
 		if (!Files.isDirectory(Paths.get(name))) {
 			try {
-				Files.createDirectory(Paths.get(name));
+				// createDirectories, not createDirectory: every caller here passes a nested path
+				// like "themes/export", and createDirectory fails outright when the parent is
+				// missing - after which the write it was preparing for silently does nothing.
+				Files.createDirectories(Paths.get(name));
 			} catch (IOException e) {
-				TheMightyArchitect.logger.warn("Could not create Folder: " + name);
+				TheMightyArchitect.logger.warn("Could not create Folder: " + name, e);
 			}
 		}
 	}
@@ -88,20 +94,54 @@ public class FilesHelper {
 	}
 
 	public static String findFirstValidFilename(String name, String folderPath, String extension) {
+		String slug = slugOr(name, "unnamed");
 		int index = 0;
 		String filename;
 		String filepath;
 		do {
-			filename = slug(name) + ((index == 0) ? "" : "_" + index) + "." + extension;
+			filename = slug + ((index == 0) ? "" : "_" + index) + "." + extension;
 			index++;
 			filepath = folderPath + "/" + filename;
 		} while (Files.exists(Paths.get(filepath)));
 		return filename;
 	}
 
+	/**
+	 * Reduces a user-supplied name to something safe to use as a single path element.
+	 * <p>
+	 * These names come from sign text and text prompts and are pasted straight into a path, so
+	 * anything outside {@code [a-z0-9_]} is dropped rather than escaped - that removes directory
+	 * separators, {@code ..}, drive colons, wildcards and control characters in one pass instead of
+	 * trying to enumerate them. Windows also reserves a handful of device names, which get a
+	 * suffix rather than being rejected.
+	 *
+	 * @return the sanitized name, which is empty when nothing usable survived
+	 */
 	public static String slug(String name) {
-		return name.toLowerCase()
-			.replace(' ', '_');
+		StringBuilder builder = new StringBuilder(name.length());
+		for (char c : name.toLowerCase(Locale.ROOT)
+			.toCharArray()) {
+			if (c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '_')
+				builder.append(c);
+			else if (c == ' ' || c == '-' || c == '.')
+				builder.append('_');
+		}
+
+		while (builder.length() > 0 && builder.charAt(0) == '_')
+			builder.deleteCharAt(0);
+		while (builder.length() > 0 && builder.charAt(builder.length() - 1) == '_')
+			builder.deleteCharAt(builder.length() - 1);
+
+		String slug = builder.toString();
+		if (slug.length() > 64)
+			slug = slug.substring(0, 64);
+		return RESERVED_NAMES.contains(slug) ? slug + "_" : slug;
+	}
+
+	/** {@link #slug(String)}, with a fallback for names that sanitize away to nothing. */
+	public static String slugOr(String name, String fallback) {
+		String slug = slug(name);
+		return slug.isEmpty() ? fallback : slug;
 	}
 
 	public static boolean saveTagCompoundAsJson(CompoundTag compound, String path) {
@@ -123,25 +163,24 @@ public class FilesHelper {
 	}
 
 	public static CompoundTag loadJsonNBT(InputStream inputStream) {
-		try {
-			JsonReader reader = new JsonReader(new BufferedReader(new InputStreamReader(inputStream)));
+		if (inputStream == null)
+			return null;
+
+		try (JsonReader reader =
+			new JsonReader(new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8)))) {
 			reader.setLenient(true);
 			JsonElement element = Streams.parse(reader);
-			reader.close();
-			inputStream.close();
 			//? if >=1.21.6 {
 			return TagParser.create(net.minecraft.nbt.NbtOps.INSTANCE).parseCompoundFully(element.toString());
-		} catch (Exception e) {
 			//?} else {
 			/*return TagParser.parseTag(element.toString());
-		} catch (IOException e) {
 			*///?}
-			e.printStackTrace();
-		//? if >=1.21.6 {
-		//?} else {
-		/*} catch (CommandSyntaxException e) {
-			e.printStackTrace();
-		*///?}
+
+		} catch (Exception e) {
+			// Exception rather than the exact types: the parser throws a checked
+			// CommandSyntaxException before 1.21.6 and an unchecked parse error after it, and
+			// either way one malformed file must not abort the load of every other one.
+			TheMightyArchitect.logger.error("Could not read NBT from json", e);
 		}
 		return null;
 	}
@@ -151,11 +190,12 @@ public class FilesHelper {
 			.getResourceAsStream(filepath));
 	}
 
+	/** @return the file's contents, or null if it is missing or unreadable - callers must check. */
 	public static CompoundTag loadJsonAsNBT(String filepath) {
 		try {
 			return loadJsonNBT(Files.newInputStream(Paths.get(filepath), StandardOpenOption.READ));
 		} catch (IOException e) {
-			e.printStackTrace();
+			TheMightyArchitect.logger.error("Could not open " + filepath, e);
 		}
 		return null;
 	}


### PR DESCRIPTION
Closes every P1 item in [`themightyarchitectury/code-audit`](https://github.com/TimStewartJ/TheMightyArchitectury) — the "correctness bugs affecting users today" tier. All nine are independent, none touch a guard arm that P3.2 will later collapse, so they ship together. This is roadmap item 3, widened from P1.1/P1.2/P1.4 to the whole tier.

## The two that destroy user work

**P1.1 — design filenames were Java object dumps on 11 of 13 nodes.** The `>=1.20` arm read `sign.getFrontText().toString()`, and `SignText` has no `toString()` override, so designs saved as `...SignText@6f1a2b`. Worse, that name is echoed back onto the sign by `PlaceSignPacket`, so it churned on every export — and the next export wrote a *new* orphan file instead of overwriting, so the stale design kept loading forever. Now it reads line two (`getMessage(1, false)`), sanitizes it and appends `.json` **idempotently**, so re-exporting overwrites. A blank sign falls back to the indexed name instead of writing a file called `.json`.

**P1.2 — extending a built-in theme deleted its built-in designs.** `designMap.putAll(externals)` replaces per *layer*, and `loadThemeFromFolder` emits an entry for every layer. So the moment `themes/<builtin>/` existed on disk — which exporting a single design creates — every built-in design in that layer disappeared. Now merged per design set and unioned.

## The rest

| | |
|---|---|
| **P1.3** | `Cuboid` overrode `equals` without `hashCode` while `Room`/`Stack` are map keys. `hashCode` now matches `equals`, and the two design caches say identity outright — a `Room` is mutable and dragged in place, so a value-based hash would strand its cached design on the first move. |
| **P1.4** | The default palette is a shared mutable singleton; `createTheme` and the scanning palette stored it directly, so recolouring one theme recoloured the palette every later theme starts from. Cloned at each storage point, including the secondary-from-primary fallback. |
| **P1.5** | `PaletteDefinition.fromNBT` dereferenced `Minecraft.getInstance().level` unguarded — the reason palette loading had to be deferred until in-world. Blocks live in the built-in registry on both sides, so it uses that instead and needs no world at all. |
| **P1.6** | Null returns dereferenced, streams leaked. One malformed palette or theme file NPE'd and took every other one with it. Every `Files.list`, `DirectoryStream`, `InputStream` and `JsonReader` is try-with-resources; results are null-checked; the render path's buffer cache returns an empty buffer instead of `null`. |
| **P1.7** | `createFolderIfMissing` used `createDirectory`, which fails on a missing parent — `themes/export` warned, then wrote nothing. |
| **P1.8** | `slug()` only lowercased and replaced spaces. Now keeps `[a-z0-9_]` and drops the rest, which removes separators, `..`, colons and control characters in one pass, and suffixes the Windows device names. |
| **P1.9** | One unknown enum name killed the whole theme list — `DesignLayer.valueOf` threw out of the single `try` wrapping the entire directory scan. Unknown names are skipped with a warning, and each theme is now isolated from the scan. |

## Verification

`javap` against all 13 named jars before writing any of it:

- `SignText.getMessage(int, boolean)` exists on every version `>=1.20`, and `SignText` itself is absent on 1.19.4 — matching the existing guard exactly.
- `Registry` implements `HolderLookup.RegistryLookup` **only from 1.21.4**, and `asLookup()` exists **only before it** — so P1.5 needs a `>=1.21.4` guard, not the unguarded `BuiltInRegistries.BLOCK` that looks like it would work.
- `NbtUtils.readBlockState` takes a `HolderGetter<Block>` on all 13, and `ListTag` iterates `Tag` on all 13.

Compiled locally at every guard boundary this PR crosses — Fabric 1.19.4 / 1.21.1 / 1.21.4 / 1.21.6 / 26.2, plus Forge 1.19.4 and NeoForge 26.2 with both test source sets — and read the resolved output under `common/versions/1.19.4/build/generated/stonecutter/`. The full 25-target matrix is CI's job.

## New assertions

The client test gains six checks covering the four fixes that are pure logic: filename derivation, idempotence, the blank-sign fallback and traversal; palette independence; lenient enum parsing; the `hashCode`/`equals` contract. These want JUnit — which the mod still does not have, and which is roadmap item 9 — but an assertion that runs on all 25 targets beats one that runs nowhere.
