### PR TITLE
De-duplicate the whole-file guarded copies (P3.2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Cheap structural gate, in parallel with the 13 build jobs. Guards the bug class PR #34 vs #32
+  # demonstrated: a guard that wraps a whole file gives every version its own copy of the shared
+  # logic, so a fix applied to one copy silently misses the others. Marker counts hide it - one
+  # guard can wrap hundreds of duplicated lines - so this looks for the repeated `package`
+  # declaration a duplicated compilation unit necessarily carries.
+  source-shape:
+    name: Source shape
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: No whole-file guarded duplicates
+        shell: pwsh
+        run: ./scripts/check-source-shape.ps1 -Detail
+
   build:
     name: MC ${{ matrix.mc }}
     runs-on: ubuntu-latest
@@ -178,12 +192,16 @@ jobs:
   # a PR only passes when every version builds green and its metadata verifies.
   all-green:
     name: All versions green
-    needs: build
+    needs: [build, source-shape]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any matrix job failed
         run: |
+          if [ "${{ needs.source-shape.result }}" != "success" ]; then
+            echo "The source-shape gate failed."
+            exit 1
+          fi
           if [ "${{ needs.build.result }}" != "success" ]; then
             echo "One or more version builds failed."
             exit 1

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/IRenderGameOverlay.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/IRenderGameOverlay.java
@@ -1,29 +1,26 @@
-//? if >=26 {
 package com.timmie.mightyarchitect.control.phase;
 
+//? if >=26 {
 import net.minecraft.client.gui.GuiGraphicsExtractor;
-
-public interface IRenderGameOverlay {
-
-	void renderGameOverlay(GuiGraphicsExtractor ms, float partialTicks);
-	
-}
 //?} else if >=1.20 {
-/*package com.timmie.mightyarchitect.control.phase;
+/*import net.minecraft.client.gui.GuiGraphics;
+*///?} else {
+/*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
+*///?}
 
-import net.minecraft.client.gui.GuiGraphics;
-
+/**
+ * Implemented by an {@link IArchitectPhase} that draws onto the vanilla HUD.
+ * <p>
+ * Only the graphics parameter varies: 1.20 replaced the mod's own {@code GuiGraphics} shim with
+ * vanilla's, and 26 renamed vanilla's to {@code GuiGraphicsExtractor}. The declaration itself is the
+ * same on every version, so only the import and the signature are guarded.
+ */
 public interface IRenderGameOverlay {
 
-	void renderGameOverlay(GuiGraphics ms, float partialTicks);
-	
-}*///?} else {
-/*package com.timmie.mightyarchitect.control.phase;
+	//? if >=26 {
+	void renderGameOverlay(GuiGraphicsExtractor ms, float partialTicks);
+	//?} else {
+	/*void renderGameOverlay(GuiGraphics ms, float partialTicks);
+	*///?}
 
-import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
-
-public interface IRenderGameOverlay {
-
-	void renderGameOverlay(GuiGraphics ms, float partialTicks);
-	
-}*///?}
+}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperRenderTypeBuffer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/SuperRenderTypeBuffer.java
@@ -1,20 +1,59 @@
-//? if >=26.2 {
-/*package com.timmie.mightyarchitect.foundation;
+package com.timmie.mightyarchitect.foundation;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.blaze3d.vertex.VertexConsumer;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-import net.minecraft.client.renderer.SubmitNodeCollector;
+//? if >=1.21 {
+import com.mojang.blaze3d.vertex.ByteBufferBuilder;
+//?} else {
+/*import com.mojang.blaze3d.vertex.BufferBuilder;
+*///?}
+//? if >=1.21.11 {
+import net.minecraft.util.Util;
+//?} else {
+/*import net.minecraft.Util;
+*///?}
+//? if >=1.21.11 {
 import net.minecraft.client.renderer.rendertype.RenderType;
+//?} else {
+/*import net.minecraft.client.renderer.RenderType;
+*///?}
+// 26.2 removed MultiBufferSource along with immediate-mode drawing, and introduced the frame's
+// SubmitNodeCollector in its place.
+//? if >=26.2 {
+/*import net.minecraft.client.renderer.SubmitNodeCollector;
+*///?} else {
+import net.minecraft.client.renderer.MultiBufferSource;
+//?}
+import net.minecraft.client.renderer.Sheets;
+import net.minecraft.client.resources.model.ModelBakery;
 
+//? if >=1.21 {
 import java.util.SequencedMap;
+//?} else {
+/*import java.util.SortedMap;
+*///?}
 
-// 26.2 removed MultiBufferSource and immediate-mode drawing: a RenderType no longer draws, it
-// describes a pipeline, and geometry reaches the screen by being submitted to the frame's
-// SubmitNodeCollector. The mod still emits vertices the old way, so each render type's vertices are
-// recorded here and replayed inside a submitCustomGeometry callback when vanilla draws that phase.
-public class SuperRenderTypeBuffer implements MightyBuffers {
+/**
+ * The mod's three-layer draw surface: an early, a default and a late phase, so world rendering can
+ * order itself against vanilla geometry.
+ *
+ * <p>Two eras sit behind that. Up to 26.1 a phase owns vanilla immediate-mode buffers and flushes
+ * them. 26.2 removed immediate-mode drawing entirely - a {@code RenderType} no longer draws, it
+ * describes a pipeline, and geometry reaches the screen by being submitted to the frame's
+ * {@code SubmitNodeCollector} - so a phase records the vertex calls and replays them inside a
+ * {@code submitCustomGeometry} callback when vanilla draws that phase.
+ *
+ * <p>Only {@code Phase} differs between the two. The class shape, the singleton and the six
+ * entry points below are shared, so adding a phase or changing draw order cannot be done to one
+ * era and missed on the other.
+ */
+//? if >=26.2 {
+/*public class SuperRenderTypeBuffer implements MightyBuffers {
+*///?} else {
+public class SuperRenderTypeBuffer implements MultiBufferSource, MightyBuffers {
+//?}
 
 	static SuperRenderTypeBuffer instance;
 
@@ -24,7 +63,8 @@ public class SuperRenderTypeBuffer implements MightyBuffers {
 		return instance;
 	}
 
-	// The collector is only valid for the frame the loader hook handed it to us in.
+	//? if >=26.2 {
+	/*// The collector is only valid for the frame the loader hook handed it to us in.
 	private static SubmitNodeCollector collector;
 	// Recorded vertices are already transformed, so submissions carry an identity pose.
 	private static final PoseStack IDENTITY = new PoseStack();
@@ -35,16 +75,20 @@ public class SuperRenderTypeBuffer implements MightyBuffers {
 		// vanilla has already replayed last frame's callbacks and dropped its references.
 		getInstance().recycle();
 	}
+	*///?}
 
-	private final Phase earlyBuffer = new Phase();
-	private final Phase defaultBuffer = new Phase();
-	private final Phase lateBuffer = new Phase();
+	// The argument is the phase's draw order within the frame, which only 26.2 has a use for.
+	private final Phase earlyBuffer = new Phase(0);
+	private final Phase defaultBuffer = new Phase(1);
+	private final Phase lateBuffer = new Phase(2);
 
-	private void recycle() {
+	//? if >=26.2 {
+	/*private void recycle() {
 		earlyBuffer.recycle();
 		defaultBuffer.recycle();
 		lateBuffer.recycle();
 	}
+	*///?}
 
 	public VertexConsumer getEarlyBuffer(RenderType type) {
 		return earlyBuffer.buffer(type);
@@ -60,22 +104,30 @@ public class SuperRenderTypeBuffer implements MightyBuffers {
 	}
 
 	public void draw() {
-		earlyBuffer.submitAll(0);
-		defaultBuffer.submitAll(1);
-		lateBuffer.submitAll(2);
+		earlyBuffer.drawAll();
+		defaultBuffer.drawAll();
+		lateBuffer.drawAll();
 	}
 
 	public void draw(RenderType type) {
-		earlyBuffer.submitOne(0, type);
-		defaultBuffer.submitOne(1, type);
-		lateBuffer.submitOne(2, type);
+		earlyBuffer.drawOne(type);
+		defaultBuffer.drawOne(type);
+		lateBuffer.drawOne(type);
 	}
 
-	private static class Phase {
+	//? if >=26.2 {
+	/*private static class Phase {
+
+		// Vanilla replays submissions in this order.
+		private final int order;
 
 		// Kept across frames: the recordings are the per-frame scratch buffers, and reallocating
 		// them every frame is what made this path allocation-bound on large schematics.
 		private final SequencedMap<RenderType, RecordedGeometry> recordings = new Object2ObjectLinkedOpenHashMap<>();
+
+		Phase(int order) {
+			this.order = order;
+		}
 
 		VertexConsumer buffer(RenderType type) {
 			return recordings.computeIfAbsent(type, ignored -> new RecordedGeometry());
@@ -85,17 +137,17 @@ public class SuperRenderTypeBuffer implements MightyBuffers {
 			recordings.values().forEach(RecordedGeometry::reset);
 		}
 
-		void submitAll(int order) {
-			recordings.forEach((type, geometry) -> submit(order, type, geometry));
+		void drawAll() {
+			recordings.forEach(this::submit);
 		}
 
-		void submitOne(int order, RenderType type) {
+		void drawOne(RenderType type) {
 			RecordedGeometry geometry = recordings.get(type);
 			if (geometry != null)
-				submit(order, type, geometry);
+				submit(type, geometry);
 		}
 
-		private void submit(int order, RenderType type, RecordedGeometry geometry) {
+		private void submit(RenderType type, RecordedGeometry geometry) {
 			if (collector == null || geometry.isEmpty() || geometry.submitted)
 				return;
 			// Never reset the recording here: the callback replays it after this returns.
@@ -266,83 +318,8 @@ public class SuperRenderTypeBuffer implements MightyBuffers {
 			return this;
 		}
 	}
-}
-*///?} else {
-package com.timmie.mightyarchitect.foundation;
-
-//? if >=1.21 {
-import com.mojang.blaze3d.vertex.ByteBufferBuilder;
-//?} else {
-/*import com.mojang.blaze3d.vertex.BufferBuilder;
-*///?}
-import com.mojang.blaze3d.vertex.VertexConsumer;
-import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
-//? if >=1.21.11 {
-import net.minecraft.util.Util;
-//?} else {
-/*import net.minecraft.Util;
-*///?}
-import net.minecraft.client.renderer.MultiBufferSource;
-//? if >=1.21.11 {
-import net.minecraft.client.renderer.rendertype.RenderType;
-//?} else {
-/*import net.minecraft.client.renderer.RenderType;
-*///?}
-import net.minecraft.client.renderer.Sheets;
-import net.minecraft.client.resources.model.ModelBakery;
-
-//? if >=1.21 {
-import java.util.SequencedMap;
-//?} else {
-/*import java.util.SortedMap;
-*///?}
-
-public class SuperRenderTypeBuffer implements MultiBufferSource, MightyBuffers {
-
-	static SuperRenderTypeBuffer instance;
-
-	public static SuperRenderTypeBuffer getInstance() {
-		if (instance == null)
-			instance = new SuperRenderTypeBuffer();
-		return instance;
-	}
-
-	SuperRenderTypeBufferPhase earlyBuffer;
-	SuperRenderTypeBufferPhase defaultBuffer;
-	SuperRenderTypeBufferPhase lateBuffer;
-
-	public SuperRenderTypeBuffer() {
-		earlyBuffer = new SuperRenderTypeBufferPhase();
-		defaultBuffer = new SuperRenderTypeBufferPhase();
-		lateBuffer = new SuperRenderTypeBufferPhase();
-	}
-
-	public VertexConsumer getEarlyBuffer(RenderType type) {
-		return earlyBuffer.bufferSource.getBuffer(type);
-	}
-
-	@Override
-	public VertexConsumer getBuffer(RenderType type) {
-		return defaultBuffer.bufferSource.getBuffer(type);
-	}
-
-	public VertexConsumer getLateBuffer(RenderType type) {
-		return lateBuffer.bufferSource.getBuffer(type);
-	}
-
-	public void draw() {
-		earlyBuffer.bufferSource.endBatch();
-		defaultBuffer.bufferSource.endBatch();
-		lateBuffer.bufferSource.endBatch();
-	}
-
-	public void draw(RenderType type) {
-		earlyBuffer.bufferSource.endBatch(type);
-		defaultBuffer.bufferSource.endBatch(type);
-		lateBuffer.bufferSource.endBatch(type);
-	}
-
-	private static class SuperRenderTypeBufferPhase {
+	*///?} else {
+	private static class Phase {
 
 		// 1.21 swapped the immediate-mode buffer pool from BufferBuilder to ByteBufferBuilder and
 		// the map type from fastutil's SortedMap view to SequencedMap.
@@ -419,20 +396,35 @@ public class SuperRenderTypeBuffer implements MultiBufferSource, MightyBuffers {
 			});
 		});
 		//? if >=1.21 {
-		private final BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new ByteBufferBuilder(256));
+		private final MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new ByteBufferBuilder(256));
 
 		private static void put(Object2ObjectLinkedOpenHashMap<RenderType, ByteBufferBuilder> map, RenderType type) {
 			map.put(type, new ByteBufferBuilder(type.bufferSize()));
 		}
 		//?} else {
-		/*private final BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new BufferBuilder(256));
+		/*private final MultiBufferSource.BufferSource bufferSource = MultiBufferSource.immediateWithBuffers(fixedBuffers, new BufferBuilder(256));
 
 		private static void put(Object2ObjectLinkedOpenHashMap<RenderType, BufferBuilder> map, RenderType type) {
 			map.put(type, new BufferBuilder(type.bufferSize()));
 		}
 		*///?}
 
+		// The draw order only means something from 26.2; here the phases are flushed in call order.
+		Phase(int order) {
+		}
+
+		VertexConsumer buffer(RenderType type) {
+			return bufferSource.getBuffer(type);
+		}
+
+		void drawAll() {
+			bufferSource.endBatch();
+		}
+
+		void drawOne(RenderType type) {
+			bufferSource.endBatch(type);
+		}
 	}
+	//?}
 
 }
-//?}

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/PostChainManager.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/utility/PostChainManager.java
@@ -1,24 +1,32 @@
-//? if >=26 {
+//? if >=1.21.4 {
 package com.timmie.mightyarchitect.foundation.utility;
 
 import com.mojang.blaze3d.pipeline.RenderTarget;
 import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
 import com.timmie.mightyarchitect.TheMightyArchitect;
+import com.timmie.mightyarchitect.foundation.compat.McCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelTargetBundle;
 import net.minecraft.client.renderer.PostChain;
+//? if >=1.21.11 {
 import net.minecraft.resources.Identifier;
+//?} else {
+/*import net.minecraft.resources.ResourceLocation;
+*///?}
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
-//*
- //* Manages post-processing shader effects using the 1.21.4 PostChain API.
- //* <p>
- //* The GameRenderer.loadEffect()/shutdownEffect() methods were removed in 1.21.4.
- //* This class provides equivalent functionality by using ShaderManager.getPostChain().
- //
+// The mod's post-processing chain, for the versions that have the declarative post_effect API.
+//
+// 1.21.4 removed GameRenderer.loadEffect()/shutdownEffect(): a chain is obtained from
+// ShaderManager.getPostChain() and processed against the main render target. Below 1.21.4 the
+// class does not exist at all - Shaders drives GameRendererAccessor instead - which is why the
+// whole file is one arm rather than a set of guarded members.
+//
+// Documentation here is written as line comments on purpose. An inactive arm is wrapped in a
+// block comment, so a nested */ would close the wrapper early and spill the rest into live code.
 public class PostChainManager {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TheMightyArchitect.ID);
@@ -27,15 +35,20 @@ public class PostChainManager {
     private static PostChain activePostChain = null;
 
     @Nullable
+    //? if >=1.21.11 {
     private static Identifier activeShaderLocation = null;
+    //?} else {
+    /*private static ResourceLocation activeShaderLocation = null;
+    *///?}
 
-    //*
-     //* Loads and activates a post-processing shader.
-     //*
-     //* @param shaderLocation The resource location of the shader (e.g., "mightyarchitect:blueprint")
-     //* @return true if the shader was loaded successfully, false otherwise
-     //
+    // Loads and activates a post-processing shader, addressed as namespace:name and resolved to
+    // post_effect/<name>.json. An empty path means "no shader". Returns whether the requested
+    // state was reached.
+    //? if >=1.21.11 {
     public static boolean loadShader(Identifier shaderLocation) {
+    //?} else {
+    /*public static boolean loadShader(ResourceLocation shaderLocation) {
+    *///?}
         Minecraft mc = Minecraft.getInstance();
 
         // Don't reload if the same shader is already active
@@ -47,15 +60,13 @@ public class PostChainManager {
         shutdownShader();
 
         if (shaderLocation.getPath().isEmpty()) {
-            // Empty path means "no shader"
             return true;
         }
 
         try {
-            // PostChain is obtained via ShaderManager.getPostChain().
-            // Use LevelTargetBundle.MAIN_TARGETS to declare available external targets (like vanilla does)
+            // LevelTargetBundle.MAIN_TARGETS declares the available external targets, as vanilla does
             activePostChain = mc.getShaderManager().getPostChain(
-                shaderLocation, 
+                shaderLocation,
                 LevelTargetBundle.MAIN_TARGETS
             );
             activeShaderLocation = shaderLocation;
@@ -70,9 +81,7 @@ public class PostChainManager {
         }
     }
 
-    //*
-     //* Shuts down the currently active post-processing shader.
-     //
+    // Drops the active post-processing shader, if there is one.
     public static void shutdownShader() {
         if (activePostChain != null) {
             activePostChain = null;
@@ -81,501 +90,53 @@ public class PostChainManager {
         }
     }
 
-    //*
-     //* Processes the active post-processing shader using the UNPOOLED resource allocator.
-     //* This is the NeoForge entry point (via {@code RenderLevelStageEvent}), which does not
-     //* expose GameRenderer's pooled resource allocator. The Fabric mixin path uses the
-     //* {@link #processShader(float, GraphicsResourceAllocator)} overload with the pooled allocator.
-     //*
-     //* @param partialTicks The partial tick time
-     //
+    // Processes the active shader with the UNPOOLED allocator. This is the NeoForge entry point
+    // (via RenderLevelStageEvent), which does not expose GameRenderer's pooled resource allocator.
+    // The Fabric mixin path calls the overload below with the pooled one instead.
     public static void processShader(float partialTicks) {
         processShader(partialTicks, GraphicsResourceAllocator.UNPOOLED);
     }
 
-    //*
-     //* Processes the active post-processing shader.
-     //* This should be called after the world has been rendered to the main framebuffer.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @param resourceAllocator The graphics resource allocator (use GameRenderer's resourcePool)
-     //
+    // Processes the active shader. Call after the world has been rendered to the main framebuffer.
     public static void processShader(float partialTicks, GraphicsResourceAllocator resourceAllocator) {
         if (activePostChain == null) {
             return;
         }
 
         Minecraft mc = Minecraft.getInstance();
-        RenderTarget mainTarget = com.timmie.mightyarchitect.foundation.compat.McCompat.mainRenderTarget(mc);
+        RenderTarget mainTarget = McCompat.mainRenderTarget(mc);
 
-        // Apply the post-processing effect using the provided resource allocator (like vanilla does)
         activePostChain.process(mainTarget, resourceAllocator);
+
+        // Before 1.21.6 the post pass leaves the main target unbound, so subsequent rendering would
+        // draw into whatever the chain bound last. From 1.21.6 the pipeline rebinds it itself.
+        //? if <1.21.6 {
+        /*mainTarget.bindWrite(false);
+        *///?}
     }
 
-    //*
-     //* Checks if a shader is currently active.
-     //*
-     //* @return true if a post-processing shader is active
-     //
+    // Whether any post-processing shader is active.
     public static boolean isShaderActive() {
         return activePostChain != null;
     }
 
-    //*
-     //* Checks if a specific shader is currently active.
-     //*
-     //* @param shaderLocation The shader location to check
-     //* @return true if the specified shader is active
-     //
+    // Whether the given post-processing shader is the active one.
+    //? if >=1.21.11 {
     public static boolean isShaderActive(Identifier shaderLocation) {
+    //?} else {
+    /*public static boolean isShaderActive(ResourceLocation shaderLocation) {
+    *///?}
         return activePostChain != null && shaderLocation.equals(activeShaderLocation);
     }
 
-    //*
-     //* Gets the currently active shader location.
-     //*
-     //* @return The active shader location, or null if no shader is active
-     //
+    // The active shader's location, or null when no shader is active.
     @Nullable
+    //? if >=1.21.11 {
     public static Identifier getActiveShaderLocation() {
+    //?} else {
+    /*public static ResourceLocation getActiveShaderLocation() {
+    *///?}
         return activeShaderLocation;
     }
 }
-//?} else if >=1.21.11 {
-/*package com.timmie.mightyarchitect.foundation.utility;
-
-import com.mojang.blaze3d.pipeline.RenderTarget;
-import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
-import com.timmie.mightyarchitect.TheMightyArchitect;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.LevelTargetBundle;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.resources.Identifier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-
-//*
- //* Manages post-processing shader effects using the 1.21.4 PostChain API.
- //* <p>
- //* The GameRenderer.loadEffect()/shutdownEffect() methods were removed in 1.21.4.
- //* This class provides equivalent functionality by using ShaderManager.getPostChain().
- //
-public class PostChainManager {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TheMightyArchitect.ID);
-
-    @Nullable
-    private static PostChain activePostChain = null;
-
-    @Nullable
-    private static Identifier activeShaderLocation = null;
-
-    //*
-     //* Loads and activates a post-processing shader.
-     //*
-     //* @param shaderLocation The resource location of the shader (e.g., "mightyarchitect:blueprint")
-     //* @return true if the shader was loaded successfully, false otherwise
-     //
-    public static boolean loadShader(Identifier shaderLocation) {
-        Minecraft mc = Minecraft.getInstance();
-
-        // Don't reload if the same shader is already active
-        if (activePostChain != null && shaderLocation.equals(activeShaderLocation)) {
-            return true;
-        }
-
-        // Shutdown any existing shader first
-        shutdownShader();
-
-        if (shaderLocation.getPath().isEmpty()) {
-            // Empty path means "no shader"
-            return true;
-        }
-
-        try {
-            // In 1.21.4, PostChain is obtained via ShaderManager.getPostChain()
-            // Use LevelTargetBundle.MAIN_TARGETS to declare available external targets (like vanilla does)
-            activePostChain = mc.getShaderManager().getPostChain(
-                shaderLocation, 
-                LevelTargetBundle.MAIN_TARGETS
-            );
-            activeShaderLocation = shaderLocation;
-
-            LOGGER.debug("Loaded post-processing shader: {}", shaderLocation);
-            return true;
-        } catch (Exception e) {
-            LOGGER.error("Failed to load post-processing shader: {}", shaderLocation, e);
-            activePostChain = null;
-            activeShaderLocation = null;
-            return false;
-        }
-    }
-
-    //*
-     //* Shuts down the currently active post-processing shader.
-     //
-    public static void shutdownShader() {
-        if (activePostChain != null) {
-            activePostChain = null;
-            activeShaderLocation = null;
-            LOGGER.debug("Shutdown post-processing shader");
-        }
-    }
-
-    //*
-     //* Processes the active post-processing shader using UNPOOLED resource allocator.
-     //* For optimal performance, prefer the overload that accepts a GraphicsResourceAllocator.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @deprecated Use {@link #processShader(float, GraphicsResourceAllocator)} with GameRenderer's resourcePool
-     //
-    @Deprecated
-    public static void processShader(float partialTicks) {
-        processShader(partialTicks, GraphicsResourceAllocator.UNPOOLED);
-    }
-
-    //*
-     //* Processes the active post-processing shader.
-     //* This should be called after the world has been rendered to the main framebuffer.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @param resourceAllocator The graphics resource allocator (use GameRenderer's resourcePool)
-     //
-    public static void processShader(float partialTicks, GraphicsResourceAllocator resourceAllocator) {
-        if (activePostChain == null) {
-            return;
-        }
-
-        Minecraft mc = Minecraft.getInstance();
-        RenderTarget mainTarget = com.timmie.mightyarchitect.foundation.compat.McCompat.mainRenderTarget(mc);
-
-        // Apply the post-processing effect using the provided resource allocator (like vanilla does)
-        activePostChain.process(mainTarget, resourceAllocator);
-
-        // In 1.21.6, framebuffer binding is handled internally by the pipeline
-    }
-
-    //*
-     //* Checks if a shader is currently active.
-     //*
-     //* @return true if a post-processing shader is active
-     //
-    public static boolean isShaderActive() {
-        return activePostChain != null;
-    }
-
-    //*
-     //* Checks if a specific shader is currently active.
-     //*
-     //* @param shaderLocation The shader location to check
-     //* @return true if the specified shader is active
-     //
-    public static boolean isShaderActive(Identifier shaderLocation) {
-        return activePostChain != null && shaderLocation.equals(activeShaderLocation);
-    }
-
-    //*
-     //* Gets the currently active shader location.
-     //*
-     //* @return The active shader location, or null if no shader is active
-     //
-    @Nullable
-    public static Identifier getActiveShaderLocation() {
-        return activeShaderLocation;
-    }
-}*/
-//?} else if >=1.21.6 {
-/*package com.timmie.mightyarchitect.foundation.utility;
-
-import com.mojang.blaze3d.pipeline.RenderTarget;
-import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
-import com.timmie.mightyarchitect.TheMightyArchitect;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.LevelTargetBundle;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.resources.ResourceLocation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-
-//*
- //* Manages post-processing shader effects using the 1.21.4 PostChain API.
- //* <p>
- //* The GameRenderer.loadEffect()/shutdownEffect() methods were removed in 1.21.4.
- //* This class provides equivalent functionality by using ShaderManager.getPostChain().
- //
-public class PostChainManager {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TheMightyArchitect.ID);
-
-    @Nullable
-    private static PostChain activePostChain = null;
-
-    @Nullable
-    private static ResourceLocation activeShaderLocation = null;
-
-    //*
-     //* Loads and activates a post-processing shader.
-     //*
-     //* @param shaderLocation The resource location of the shader (e.g., "mightyarchitect:blueprint")
-     //* @return true if the shader was loaded successfully, false otherwise
-     //
-    public static boolean loadShader(ResourceLocation shaderLocation) {
-        Minecraft mc = Minecraft.getInstance();
-
-        // Don't reload if the same shader is already active
-        if (activePostChain != null && shaderLocation.equals(activeShaderLocation)) {
-            return true;
-        }
-
-        // Shutdown any existing shader first
-        shutdownShader();
-
-        if (shaderLocation.getPath().isEmpty()) {
-            // Empty path means "no shader"
-            return true;
-        }
-
-        try {
-            // In 1.21.4, PostChain is obtained via ShaderManager.getPostChain()
-            // Use LevelTargetBundle.MAIN_TARGETS to declare available external targets (like vanilla does)
-            activePostChain = mc.getShaderManager().getPostChain(
-                shaderLocation, 
-                LevelTargetBundle.MAIN_TARGETS
-            );
-            activeShaderLocation = shaderLocation;
-
-            LOGGER.debug("Loaded post-processing shader: {}", shaderLocation);
-            return true;
-        } catch (Exception e) {
-            LOGGER.error("Failed to load post-processing shader: {}", shaderLocation, e);
-            activePostChain = null;
-            activeShaderLocation = null;
-            return false;
-        }
-    }
-
-    //*
-     //* Shuts down the currently active post-processing shader.
-     //
-    public static void shutdownShader() {
-        if (activePostChain != null) {
-            activePostChain = null;
-            activeShaderLocation = null;
-            LOGGER.debug("Shutdown post-processing shader");
-        }
-    }
-
-    //*
-     //* Processes the active post-processing shader using UNPOOLED resource allocator.
-     //* For optimal performance, prefer the overload that accepts a GraphicsResourceAllocator.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @deprecated Use {@link #processShader(float, GraphicsResourceAllocator)} with GameRenderer's resourcePool
-     //
-    @Deprecated
-    public static void processShader(float partialTicks) {
-        processShader(partialTicks, GraphicsResourceAllocator.UNPOOLED);
-    }
-
-    //*
-     //* Processes the active post-processing shader.
-     //* This should be called after the world has been rendered to the main framebuffer.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @param resourceAllocator The graphics resource allocator (use GameRenderer's resourcePool)
-     //
-    public static void processShader(float partialTicks, GraphicsResourceAllocator resourceAllocator) {
-        if (activePostChain == null) {
-            return;
-        }
-
-        Minecraft mc = Minecraft.getInstance();
-        RenderTarget mainTarget = com.timmie.mightyarchitect.foundation.compat.McCompat.mainRenderTarget(mc);
-
-        // Apply the post-processing effect using the provided resource allocator (like vanilla does)
-        activePostChain.process(mainTarget, resourceAllocator);
-
-        // In 1.21.6, framebuffer binding is handled internally by the pipeline
-    }
-
-    //*
-     //* Checks if a shader is currently active.
-     //*
-     //* @return true if a post-processing shader is active
-     //
-    public static boolean isShaderActive() {
-        return activePostChain != null;
-    }
-
-    //*
-     //* Checks if a specific shader is currently active.
-     //*
-     //* @param shaderLocation The shader location to check
-     //* @return true if the specified shader is active
-     //
-    public static boolean isShaderActive(ResourceLocation shaderLocation) {
-        return activePostChain != null && shaderLocation.equals(activeShaderLocation);
-    }
-
-    //*
-     //* Gets the currently active shader location.
-     //*
-     //* @return The active shader location, or null if no shader is active
-     //
-    @Nullable
-    public static ResourceLocation getActiveShaderLocation() {
-        return activeShaderLocation;
-    }
-}*/
-//?} else if >=1.21.4 {
-/*package com.timmie.mightyarchitect.foundation.utility;
-
-import com.mojang.blaze3d.pipeline.RenderTarget;
-import com.mojang.blaze3d.resource.GraphicsResourceAllocator;
-import com.timmie.mightyarchitect.TheMightyArchitect;
-import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.LevelTargetBundle;
-import net.minecraft.client.renderer.PostChain;
-import net.minecraft.resources.ResourceLocation;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
-
-//*
- //* Manages post-processing shader effects using the 1.21.4 PostChain API.
- //* <p>
- //* The GameRenderer.loadEffect()/shutdownEffect() methods were removed in 1.21.4.
- //* This class provides equivalent functionality by using ShaderManager.getPostChain().
- //
-public class PostChainManager {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(TheMightyArchitect.ID);
-
-    @Nullable
-    private static PostChain activePostChain = null;
-
-    @Nullable
-    private static ResourceLocation activeShaderLocation = null;
-
-    //*
-     //* Loads and activates a post-processing shader.
-     //*
-     //* @param shaderLocation The resource location of the shader (e.g., "mightyarchitect:blueprint")
-     //* @return true if the shader was loaded successfully, false otherwise
-     //
-    public static boolean loadShader(ResourceLocation shaderLocation) {
-        Minecraft mc = Minecraft.getInstance();
-
-        // Don't reload if the same shader is already active
-        if (activePostChain != null && shaderLocation.equals(activeShaderLocation)) {
-            return true;
-        }
-
-        // Shutdown any existing shader first
-        shutdownShader();
-
-        if (shaderLocation.getPath().isEmpty()) {
-            // Empty path means "no shader"
-            return true;
-        }
-
-        try {
-            // In 1.21.4, PostChain is obtained via ShaderManager.getPostChain()
-            // Use LevelTargetBundle.MAIN_TARGETS to declare available external targets (like vanilla does)
-            activePostChain = mc.getShaderManager().getPostChain(
-                shaderLocation, 
-                LevelTargetBundle.MAIN_TARGETS
-            );
-            activeShaderLocation = shaderLocation;
-
-            LOGGER.debug("Loaded post-processing shader: {}", shaderLocation);
-            return true;
-        } catch (Exception e) {
-            LOGGER.error("Failed to load post-processing shader: {}", shaderLocation, e);
-            activePostChain = null;
-            activeShaderLocation = null;
-            return false;
-        }
-    }
-
-    //*
-     //* Shuts down the currently active post-processing shader.
-     //
-    public static void shutdownShader() {
-        if (activePostChain != null) {
-            activePostChain = null;
-            activeShaderLocation = null;
-            LOGGER.debug("Shutdown post-processing shader");
-        }
-    }
-
-    //*
-     //* Processes the active post-processing shader using UNPOOLED resource allocator.
-     //* For optimal performance, prefer the overload that accepts a GraphicsResourceAllocator.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @deprecated Use {@link #processShader(float, GraphicsResourceAllocator)} with GameRenderer's resourcePool
-     //
-    @Deprecated
-    public static void processShader(float partialTicks) {
-        processShader(partialTicks, GraphicsResourceAllocator.UNPOOLED);
-    }
-
-    //*
-     //* Processes the active post-processing shader.
-     //* This should be called after the world has been rendered to the main framebuffer.
-     //*
-     //* @param partialTicks The partial tick time
-     //* @param resourceAllocator The graphics resource allocator (use GameRenderer's resourcePool)
-     //
-    public static void processShader(float partialTicks, GraphicsResourceAllocator resourceAllocator) {
-        if (activePostChain == null) {
-            return;
-        }
-
-        Minecraft mc = Minecraft.getInstance();
-        RenderTarget mainTarget = com.timmie.mightyarchitect.foundation.compat.McCompat.mainRenderTarget(mc);
-
-        // Apply the post-processing effect using the provided resource allocator (like vanilla does)
-        activePostChain.process(mainTarget, resourceAllocator);
-
-        // Bind the main framebuffer back for subsequent rendering
-        mainTarget.bindWrite(false);
-    }
-
-    //*
-     //* Checks if a shader is currently active.
-     //*
-     //* @return true if a post-processing shader is active
-     //
-    public static boolean isShaderActive() {
-        return activePostChain != null;
-    }
-
-    //*
-     //* Checks if a specific shader is currently active.
-     //*
-     //* @param shaderLocation The shader location to check
-     //* @return true if the specified shader is active
-     //
-    public static boolean isShaderActive(ResourceLocation shaderLocation) {
-        return activePostChain != null && shaderLocation.equals(activeShaderLocation);
-    }
-
-    //*
-     //* Gets the currently active shader location.
-     //*
-     //* @return The active shader location, or null if no shader is active
-     //
-    @Nullable
-    public static ResourceLocation getActiveShaderLocation() {
-        return activeShaderLocation;
-    }
-}*/
-//?} else {
-/**///?}
+//?}

--- a/scripts/check-source-shape.ps1
+++ b/scripts/check-source-shape.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Fails when a source file carries more than one whole-file copy of itself.
+
+.DESCRIPTION
+    A Stonecutter guard is meant to wrap the lines that genuinely differ between Minecraft
+    versions. When instead it wraps the *entire file*, every version gets its own copy of the
+    shared logic and a fix applied to one copy silently misses the others - which is exactly how
+    PR #34 fixed two HudTextBuffer arms while PR #32 concurrently added two more with the old
+    constant.
+
+    Marker counts do not find this: a whole-file duplicate is one guard wrapping everything, so it
+    scores two marker lines across hundreds of duplicated ones.
+
+    The reliable signal is a repeated `package` declaration. Java allows exactly one per
+    compilation unit, so a file that contains two has two copies of itself - and, unlike counting
+    repeated type declarations, it does not fire on a file that merely guards its `extends`,
+    `implements` or annotation line, where there is only one body and nothing can drift.
+
+.PARAMETER Path
+    Source roots to scan. Defaults to the four loader source trees.
+
+.PARAMETER Detail
+    Also print the line number of each package declaration found.
+#>
+[CmdletBinding()]
+param(
+    [string[]]$Path = @('common/src', 'fabric/src', 'neoforge/src', 'forge/src'),
+    [switch]$Detail
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+
+# Matches an active `package a.b.c;` and the commented-out form Stonecutter writes for an inactive
+# arm, `/*package a.b.c;`, which is the form a duplicated copy actually appears in.
+$packageDeclaration = '^\s*(/\*)?package\s+[A-Za-z_][A-Za-z0-9_.]*\s*;'
+
+$roots = foreach ($candidate in $Path) {
+    $full = Join-Path $repoRoot $candidate
+    if (Test-Path -LiteralPath $full) { $full }
+}
+
+if (-not $roots) {
+    throw "None of the requested source roots exist under $repoRoot : $($Path -join ', ')"
+}
+
+$offenders = @()
+$scanned = 0
+
+foreach ($file in Get-ChildItem -Path $roots -Recurse -Filter *.java -File) {
+    $scanned++
+    $hits = @(Select-String -LiteralPath $file.FullName -Pattern $packageDeclaration)
+    if ($hits.Count -le 1) { continue }
+
+    $offenders += [pscustomobject]@{
+        Path        = [System.IO.Path]::GetRelativePath($repoRoot, $file.FullName).Replace('\', '/')
+        Copies      = $hits.Count
+        LineNumbers = @($hits.LineNumber)
+    }
+}
+
+Write-Host "Scanned $scanned Java files under: $($Path -join ', ')"
+
+if (-not $offenders) {
+    Write-Host 'No whole-file guarded duplicates found.'
+    exit 0
+}
+
+Write-Host ''
+foreach ($offender in $offenders | Sort-Object -Property Copies -Descending) {
+    $message = "$($offender.Path) declares its package $($offender.Copies) times - the whole file is duplicated per Stonecutter arm. Guard only the lines that differ."
+    if ($env:GITHUB_ACTIONS -eq 'true') {
+        Write-Host "::error file=$($offender.Path),line=$($offender.LineNumbers[1])::$message"
+    }
+    else {
+        Write-Host "ERROR: $message"
+    }
+    if ($Detail) {
+        Write-Host "       package declarations at lines: $($offender.LineNumbers -join ', ')"
+    }
+}
+
+Write-Host ''
+Write-Host "$($offenders.Count) file(s) contain whole-file guarded duplicates."
+exit 1


### PR DESCRIPTION
Closes the last of P3.2 in the [de-port audit](https://github.com/TimStewartJ/TheMightyArchitectury/pull/36): the files where a Stonecutter guard wraps the *whole file* instead of the lines that differ, so every version carries its own copy of the shared logic and a fix applied to one copy silently misses the others. That is the failure #34 and #32 demonstrated on `HudTextBuffer`, which #36 already fixed.

**1,158 lines of duplicated logic become 348.**

## `PostChainManager` — 4 copies, 581 → 142 lines

Four near-identical 145-line arms. Diffing them showed they differ in exactly three things:

| difference | real? |
| --- | --- |
| `Identifier` vs `ResourceLocation` | yes — `>=1.21.11` |
| `mainTarget.bindWrite(false)` after the post pass | yes — `<1.21.6` only |
| `@Deprecated` on `processShader(float)` | **no** — drift |

The third is worth calling out. Three arms carried `@Deprecated` on the no-allocator overload; the fourth carried a comment explaining that overload *is* the NeoForge `RenderLevelStageEvent` entry point, which has no access to `GameRenderer`'s pooled allocator. It is not deprecated, it is the only thing NeoForge can call. Dropped.

Everything else was duplication. The class genuinely does not exist below 1.21.4 — `Shaders` drives `GameRendererAccessor` there instead — so the file stays one arm guarded `>=1.21.4`, and `PostChainManager.class` is still absent from every jar below it.

## `IRenderGameOverlay` — 3 copies, 29 → 26 lines

Three copies of a nine-line interface differing only in the graphics parameter. Guard the import and the signature, keep one declaration — the same shape `PhaseComposing` and `PhasePreviewing` already use for the identical boundary.

## `SuperRenderTypeBuffer` — the façade, 438 → 430 lines

The one case where the two arms are genuinely different implementations rather than copies: 26.2 removed immediate-mode drawing, so a phase records vertex calls and replays them into the frame's `SubmitNodeCollector` instead of owning buffers it flushes.

The *façade around them* was duplicated all the same. The class declaration, the singleton, the three phases and the six entry points now exist once; only `Phase` is guarded. **Adding a phase or changing draw order can no longer be done to one era and missed on the other**, which is the whole point of the item. Line count barely moves — that is expected, and it is not the metric.

Two small things fall out:

- draw order moves into the `Phase` constructor, so `draw()` and `draw(RenderType)` are era-independent
- `bufferSource` is now typed `MultiBufferSource.BufferSource` explicitly. It resolved as bare `BufferSource` only because the enclosing class's *guarded* `implements` clause put it in scope — a dependency that should not exist

## The detector was wrong, so this replaces it

The audit's detector — *a file declaring its own top-level type more than once* — reports **seven** files. Four of them are false positives: they guard only a declaration line, an `extends`/`implements` clause or an annotation. There is one body, so nothing can drift, and rewriting them to satisfy the detector would contort the syntax across a guard boundary for no reduction in risk.

**Counting `package` declarations separates them exactly.** Java allows one per compilation unit, so two means two copies of the file — and a guarded `implements` clause never repeats it.

| file | type decls | package decls | genuine duplicate |
| --- | --- | --- | --- |
| `PostChainManager` | 4 | **4** | yes |
| `IRenderGameOverlay` | 3 | **3** | yes |
| `SuperRenderTypeBuffer` | 2 | **2** | yes |
| `WrappedWorld` | 2 | 1 | no — `implements BlockAndTintGetter` |
| `RenderTypes` | 2 | 1 | no — `extends RenderStateShard` |
| `MightyPacket` | 2 | 1 | no — `extends CustomPacketPayload` |
| `TheMightyArchitectForgeClient` | 2 | 1 | no — `@Mod` + entrypoint shape |

`scripts/check-source-shape.ps1` implements it. A `source-shape` job runs it in CI, in parallel with the 13 build jobs and joined to the `all-green` required check — ~20 s, so it does not move the ~16 min floor.

**Mutation-tested**, per the workflow doc: restoring the four-copy `PostChainManager` turns it red with

```
ERROR: .../PostChainManager.java declares its package 4 times - the whole file is
duplicated per Stonecutter arm. Guard only the lines that differ.
       package declarations at lines: 2, 145, 290, 435
```

and it goes green again on revert. A tool is not a gate until something runs it.

## Verification

- `./gradlew compileAll` green — **25 targets × 3 source sets**, no game launched.
- Guard resolution read out of `common/versions/<mc>/build/generated/stonecutter/**` for **all 13 versions**, not eyeballed from the arms:

| | 1.19.4 – 1.21.1 | 1.21.4 | 1.21.6 – 1.21.10 | 1.21.11+ |
| --- | --- | --- | --- | --- |
| `PostChainManager` | no class emitted | `ResourceLocation` + `bindWrite` | `ResourceLocation` | `Identifier` |

  `IRenderGameOverlay` resolves to the mod's own `GuiGraphics` shim on 1.19.4, vanilla's from 1.20, `GuiGraphicsExtractor` from 26. `SuperRenderTypeBuffer` compiles `RecordedGeometry` only on 26.2 and keeps `implements MultiBufferSource` everywhere below it.
- **Round-trip**: switching the tree to 1.21.4, then 1.19.4, then back to 26.1 leaves all three files byte-identical (`19/22`, `97/105`, `53/492` before and after). That was the open question — `PostChainManager` now carries ordinary `//` line comments inside a guarded arm rather than the `//*` pseudo-Javadoc, and this proves they survive a switch.

CI carries the runtime half: the blueprint shader and the world-space render paths are exactly what the client matrices screenshot-diff, on both the dev and production lanes.
