### PR TITLE
Add a JUnit suite for the mod's pure logic

### DIFF
--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -11,7 +11,6 @@ import com.timmie.mightyarchitect.AllItems;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.control.ArchitectManager;
-import com.timmie.mightyarchitect.control.compose.Cuboid;
 import com.timmie.mightyarchitect.control.design.DesignTheme;
 import com.timmie.mightyarchitect.control.design.DesignExporter;
 import com.timmie.mightyarchitect.control.design.Sketch;
@@ -41,11 +40,7 @@ import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.ListTag;
-import net.minecraft.nbt.StringTag;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
 
@@ -309,14 +304,7 @@ public final class ClientTestController {
         check(!PaletteStorage.getResourcePaletteNames().isEmpty(), "resource palettes loaded");
         check(!ThemeStorage.getIncluded().isEmpty(), "included themes loaded");
 
-        PaletteDefinition palette = PaletteDefinition.defaultPalette().clone();
-        palette.setName("Client Test Palette");
-        PaletteDefinition roundTrip = PaletteDefinition.fromNBT(palette.writeToNBT(new CompoundTag()));
-        check("Client Test Palette".equals(roundTrip.getName()), "palette NBT name round-tripped");
-        check(palette.get(Palette.ROOF_PRIMARY).equals(roundTrip.get(Palette.ROOF_PRIMARY)),
-            "palette NBT block state round-tripped");
-
-        checkDataIntegrityFixes();
+        checkPaletteRoundTrip();
 
         // WrappedWorld overrides methods NeoForge adds to Level that vanilla does not have. Those
         // resolve when the class is verified, so a wrong override is an AbstractMethodError the
@@ -331,51 +319,22 @@ public final class ClientTestController {
     }
 
     /**
-     * Guards the correctness fixes whose only symptom was lost user work: a design filename that
-     * was a Java object dump, a theme whose palette was the shared global default, a theme file
-     * whose one unknown layer name emptied the whole theme list.
+     * The one data-integrity assertion that is not pure logic: serializing a palette goes through
+     * the block registry, so it is worth asserting against a real, fully loaded game.
      * <p>
-     * This is pure logic that wants a unit test, but the mod has no JUnit suite yet, and an
-     * assertion that runs on all 25 targets beats one that runs nowhere.
+     * The nine assertions that used to sit here were pure version-agnostic Java - filename
+     * derivation and idempotence, {@code slug} traversal safety, palette independence, lenient
+     * enum parsing, the {@code hashCode}/{@code equals} contract. They now live in the JUnit
+     * suite under {@code unit-test/}, where they run in milliseconds instead of costing a full
+     * game boot on 25 targets to check arithmetic.
      */
-    private static void checkDataIntegrityFixes() {
-        check("my_design.json".equals(DesignExporter.designFilename("My Design")),
-            "design filename derived from sign text");
-        check("my_design.json".equals(DesignExporter.designFilename("my_design.json")),
-            "design filename is stable when the sign already carries it");
-        check(DesignExporter.designFilename("   ").isEmpty(),
-            "blank sign text falls back to an indexed design filename");
-        check(!DesignExporter.designFilename("../../evil name").contains("/")
-            && !DesignExporter.designFilename("../../evil name").contains(".."),
-            "design filename cannot escape its folder");
-
-        PaletteDefinition sharedDefault = PaletteDefinition.defaultPalette();
-        BlockState before = sharedDefault.get(Palette.ROOF_PRIMARY);
-        DesignTheme created = ThemeStorage.createTheme("Client Test Theme");
-        check(created.getDefaultPalette() != sharedDefault
-            && created.getDefaultPalette() != created.getDefaultSecondaryPalette(),
-            "new themes get their own palettes");
-        created.getDefaultPalette().put(Palette.ROOF_PRIMARY, Blocks.GOLD_BLOCK);
-        check(sharedDefault.get(Palette.ROOF_PRIMARY).equals(before),
-            "editing a theme palette leaves the default palette alone");
-        check(!created.getFilePath().isEmpty() && !created.getFilePath().contains("/"),
-            "theme file path is a single sanitized folder name");
-
-        ListTag layers = new ListTag();
-        layers.add(StringTag.valueOf("Regular"));
-        layers.add(StringTag.valueOf("NotALayerThisBuildKnows"));
-        CompoundTag themeTag = new CompoundTag();
-        themeTag.putString("Name", "Client Test Theme");
-        themeTag.putString("Designer", "client-test");
-        themeTag.put("Layers", layers);
-        themeTag.put("Types", new ListTag());
-        DesignTheme lenient = DesignTheme.fromNBT(themeTag);
-        check(lenient != null && lenient.getLayers().size() == 1,
-            "an unknown layer name is skipped instead of throwing");
-
-        BlockPos origin = new BlockPos(4, 5, 6);
-        check(new Cuboid(origin, 1, 2, 3).hashCode() == new Cuboid(origin, 1, 2, 3).hashCode(),
-            "equal cuboids hash equally");
+    private static void checkPaletteRoundTrip() {
+        PaletteDefinition palette = PaletteDefinition.defaultPalette().clone();
+        palette.setName("Client Test Palette");
+        PaletteDefinition roundTrip = PaletteDefinition.fromNBT(palette.writeToNBT(new CompoundTag()));
+        check("Client Test Palette".equals(roundTrip.getName()), "palette NBT name round-tripped");
+        check(palette.get(Palette.ROOF_PRIMARY).equals(roundTrip.get(Palette.ROOF_PRIMARY)),
+            "palette NBT block state round-tripped");
     }
 
     private static void captureBaseline(Minecraft minecraft) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/Schematic.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/Schematic.java
@@ -163,6 +163,22 @@ public class Schematic {
 	}
 
 	private void checkBounds(BlockPos pos) {
+		bounds = growToInclude(bounds, pos);
+	}
+
+	/**
+	 * Grows a bounding box to include one position, creating it when there is none yet.
+	 * <p>
+	 * Pure integer arithmetic, and the only part of {@link #materializeSketch()} that is: the rest
+	 * of it ends in a {@code TemplateBlockAccess}, which reads the client's level and so cannot be
+	 * built outside a running game. Kept static and public for that reason - it is what the unit
+	 * suite asserts, one block at a time, instead of paying a game boot to check addition.
+	 *
+	 * @param bounds the box so far, or null before the first position
+	 * @param pos    a position that must end up inside the box
+	 * @return the grown box, which is {@code bounds} itself when one was supplied
+	 */
+	public static Cuboid growToInclude(Cuboid bounds, BlockPos pos) {
 		if (bounds == null)
 			bounds = new Room(pos, BlockPos.ZERO);
 
@@ -191,6 +207,8 @@ public class Schematic {
 			bounds.height = y - bounds.y + 1;
 		if (z >= maxPos.getZ())
 			bounds.length = z - bounds.z + 1;
+
+		return bounds;
 	}
 
 	public StructureTemplate writeToTemplate() {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/design/ThemeStorage.java
@@ -78,10 +78,21 @@ public class ThemeStorage {
 	}
 
 	public static DesignTheme createTheme(String name) {
+		return createTheme(name, Minecraft.getInstance().player.getName()
+			.getString());
+	}
+
+	/**
+	 * Builds a new empty theme with its own palettes.
+	 * <p>
+	 * The designer is a parameter rather than read from the client here so that the part of this
+	 * that is pure - the name fallback, the file-path slug and the palette cloning - can be
+	 * asserted without a running game. {@link #createTheme(String)} supplies the local player.
+	 */
+	public static DesignTheme createTheme(String name, String designer) {
 		if (name.isEmpty())
 			name = "My Theme";
-		DesignTheme theme = new DesignTheme(name, Minecraft.getInstance().player.getName()
-			.getString());
+		DesignTheme theme = new DesignTheme(name, designer);
 		theme.setFilePath(FilesHelper.slugOr(name, "my_theme"));
 		theme.setImported(true);
 		// Clones: storing defaultPalette() itself handed the palette editor the shared default, so

--- a/common/src/main/java/com/timmie/mightyarchitect/networking/InstantPrintPacket.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/networking/InstantPrintPacket.java
@@ -28,6 +28,15 @@ import java.util.function.Predicate;
 
 public class InstantPrintPacket implements MightyPacket {
 
+	/**
+	 * Largest number of blocks one packet may carry.
+	 * <p>
+	 * Both a chunking bound on the way out and a decode-time bound on the way in: the block count
+	 * is read straight off the wire and drives an allocating loop, so a packet declaring more than
+	 * {@link #sendSchematic} could ever produce is refused rather than trusted.
+	 */
+	public static final int MAX_BLOCKS_PER_PACKET = 32;
+
 	private BunchOfBlocks blocks;
 
 	public InstantPrintPacket(BunchOfBlocks blocks) {
@@ -41,11 +50,11 @@ public class InstantPrintPacket implements MightyPacket {
 	*///?}
 		// Store raw NBT data to decode on server side with proper registry
 		int size = buf.readInt();
-		// sendSchematic never emits more than MAX_SIZE per packet, so anything larger is either
-		// corrupt or hostile - and this loop allocates per iteration.
-		if (size < 0 || size > BunchOfBlocks.MAX_SIZE)
+		// sendSchematic never emits more than MAX_BLOCKS_PER_PACKET per packet, so anything larger
+		// is either corrupt or hostile - and this loop allocates per iteration.
+		if (size < 0 || size > MAX_BLOCKS_PER_PACKET)
 			throw new DecoderException(
-				"InstantPrintPacket declared " + size + " blocks; the limit is " + BunchOfBlocks.MAX_SIZE);
+				"InstantPrintPacket declared " + size + " blocks; the limit is " + MAX_BLOCKS_PER_PACKET);
 		this.blocks = new BunchOfBlocks(new HashMap<>());
 		this.blocks.rawData = new ArrayList<>();
 		this.blocks.size = size;
@@ -133,13 +142,13 @@ public class InstantPrintPacket implements MightyPacket {
 	public static List<InstantPrintPacket> sendSchematic(Map<BlockPos, BlockState> blockMap, BlockPos anchor) {
 		List<InstantPrintPacket> packets = new LinkedList<>();
 
-		Map<BlockPos, BlockState> currentMap = new HashMap<>(BunchOfBlocks.MAX_SIZE);
+		Map<BlockPos, BlockState> currentMap = new HashMap<>(MAX_BLOCKS_PER_PACKET);
 		List<BlockPos> posList = new ArrayList<>(blockMap.keySet());
 
 		for (int i = 0; i < blockMap.size(); i++) {
-			if (currentMap.size() >= BunchOfBlocks.MAX_SIZE) {
+			if (currentMap.size() >= MAX_BLOCKS_PER_PACKET) {
 				packets.add(new InstantPrintPacket(new BunchOfBlocks(currentMap)));
-				currentMap = new HashMap<>(BunchOfBlocks.MAX_SIZE);
+				currentMap = new HashMap<>(MAX_BLOCKS_PER_PACKET);
 			}
 			currentMap.put(posList.get(i).offset(anchor), blockMap.get(posList.get(i)));
 		}
@@ -148,10 +157,25 @@ public class InstantPrintPacket implements MightyPacket {
 		return packets;
 	}
 
+	/**
+	 * The blocks this packet is carrying, at their final world positions.
+	 * <p>
+	 * Populated on the sending side by {@link #sendSchematic}. A packet that came off the wire
+	 * carries undecoded NBT instead and returns an empty map here - {@link #apply} is what reads
+	 * that side.
+	 */
+	public Map<BlockPos, BlockState> blocks() {
+		return Collections.unmodifiableMap(blocks.blocks);
+	}
+
+	/** How many blocks this packet declares, which is what the decoder bounds-checks. */
+	public int size() {
+		return blocks.size;
+	}
+
 	record BlockData(CompoundTag tag, BlockPos pos) {}
 
 	static class BunchOfBlocks {
-		static final int MAX_SIZE = 32;
 		Map<BlockPos, BlockState> blocks;
 		List<BlockData> rawData;
 		int size;

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -71,6 +71,13 @@ sourceSets {
         compileClasspath += sourceSets.main.output + sourceSets.main.compileClasspath
         runtimeClasspath += output + compileClasspath + sourceSets.main.runtimeClasspath
     }
+    // JUnit suite for the mod's pure, version-agnostic logic. Like the other two companions it is
+    // NOT Stonecutter-processed, so everything in it has to compile unchanged on every node - which
+    // is exactly the property that makes running it on all thirteen of them meaningful.
+    test {
+        java.srcDirs = [rootProject.file("unit-test/src/main/java")]
+        resources.srcDirs = []
+    }
 }
 
 // The generated common sources are task output, so the dependency has to be declared explicitly -
@@ -126,6 +133,11 @@ dependencies {
         modImplementation "net.fabricmc.fabric-api:fabric-api:${fapiVersion}"
     }
     implementation 'com.google.code.findbugs:jsr305:3.0.2'
+    // Runs the JUnit suite inside a real Fabric Loader (Knot) classloader, the way the game loads
+    // the mod, rather than off a plain classpath. Published in lockstep with the loader, so it
+    // follows this node's pinned loader version. It brings junit-jupiter-engine and
+    // junit-platform-launcher with it; no separate JUnit coordinates are needed.
+    testImplementation "net.fabricmc:fabric-loader-junit:${floaderVersion}"
     // The production run loads real mod jars, so Fabric API has to be there as one. This is a
     // plain configuration on purpose: the published artifact is already in the runtime namespace,
     // and routing it through modImplementation would hand the run a dev-mapped jar instead.
@@ -142,6 +154,29 @@ tasks.named("runAutomatedClientTest") {
 
 tasks.named("runAutomatedServerTest") {
     dependsOn tasks.named("serverTestClasses")
+}
+
+// The unit suite runs on this node's own toolchain and mappings. `test` is already wired into
+// `check` -> `build`, so every node's CI job runs it without a workflow change, and locally a
+// single node's suite is the seconds-long inner loop the CI matrix cannot be.
+def unitTestRunDir = layout.buildDirectory.dir("unit-test-run")
+
+tasks.named("test", Test) {
+    useJUnitPlatform()
+    dependsOn commonGenerate
+    // Fabric Loader's JUnit launcher builds Knot for this side and installs its classloader as the
+    // context loader for the whole session. CLIENT is the default and the wider of the two: the
+    // mod's shared classes are compiled against the client-inclusive merged jar.
+    systemProperty "fabric.side", "client"
+    // Booting Minecraft's registries starts its log4j appenders, which write `logs/latest.log`
+    // relative to the working directory - and the mod's own storage paths are relative too. Left
+    // on the default that is the project directory, so the suite would litter the source tree.
+    doFirst { unitTestRunDir.get().asFile.mkdirs() }
+    workingDir = unitTestRunDir.get().asFile
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
 }
 
 processResources {

--- a/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
+++ b/server-test/src/main/java/com/timmie/mightyarchitect/test/server/ServerPrintTest.java
@@ -119,9 +119,9 @@ public final class ServerPrintTest {
     }
 
     /**
-     * More entries than {@code BunchOfBlocks.MAX_SIZE} so the payload has to split, and one
-     * non-default blockstate property so the NBT round-trip is genuinely exercised rather than
-     * every block decoding to its default state.
+     * More entries than {@link InstantPrintPacket#MAX_BLOCKS_PER_PACKET} so the payload has to
+     * split, and one non-default blockstate property so the NBT round-trip is genuinely exercised
+     * rather than every block decoding to its default state.
      */
     private static Map<BlockPos, BlockState> buildSchematic() {
         BlockState[] palette = {

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -38,3 +38,16 @@ tasks.register("compileAll") {
     dependsOn loaderNodePaths("compileClientTestJava")
     dependsOn loaderNodePaths("compileServerTestJava")
 }
+
+// The JUnit suite for the mod's pure logic, on every version at once. It lives on the Fabric
+// branch (fabric-loader-junit is what runs it), and the code it covers is loader-agnostic, so this
+// is the whole suite rather than a third of it. Seconds per node, and the only gate in the project
+// that does not launch a game - `:fabric:<mc>:test` alone is the inner loop.
+tasks.register("unitTestAll") {
+    group = "verification"
+    description = "Runs the JUnit suite against every Minecraft version's classpath."
+    dependsOn stonecutter.versions
+        .collect { v -> rootProject.findProject(":fabric:${v.project}") }
+        .findAll { it != null }
+        .collect { "${it.path}:test" }
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/CuboidTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/CuboidTest.java
@@ -1,0 +1,343 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.compose.Cuboid;
+import com.timmie.mightyarchitect.control.compose.Room;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@link Cuboid} is the composer's geometry primitive - every room, stack and selection is one.
+ * It is plain integer arithmetic over {@link BlockPos}, so all of it belongs here.
+ */
+@Bootstrapped
+@DisplayName("Cuboid")
+class CuboidTest {
+
+	private static final BlockPos ORIGIN = new BlockPos(4, 5, 6);
+
+	@Nested
+	@DisplayName("normalization")
+	class Normalization {
+
+		@Test
+		@DisplayName("a positive size is kept as given")
+		void positiveSize() {
+			Cuboid cuboid = new Cuboid(ORIGIN, 1, 2, 3);
+
+			assertEquals(ORIGIN, cuboid.getOrigin());
+			assertEquals(new BlockPos(1, 2, 3), cuboid.getSize());
+		}
+
+		/** Dragging a selection backwards produces negative extents; the origin has to follow. */
+		@Test
+		@DisplayName("a negative size moves the origin and is stored positive")
+		void negativeSizeMovesTheOrigin() {
+			Cuboid dragged = new Cuboid(ORIGIN, -2, -3, -4);
+
+			assertEquals(new BlockPos(2, 2, 2), dragged.getOrigin());
+			assertEquals(new BlockPos(2, 3, 4), dragged.getSize());
+		}
+
+		@Test
+		@DisplayName("a mixed-sign size normalizes per axis")
+		void mixedSignSize() {
+			Cuboid dragged = new Cuboid(ORIGIN, -2, 3, -4);
+
+			assertEquals(new BlockPos(2, 5, 2), dragged.getOrigin());
+			assertEquals(new BlockPos(2, 3, 4), dragged.getSize());
+		}
+
+		@Test
+		@DisplayName("the BlockPos constructor agrees with the int one")
+		void blockPosConstructorAgrees() {
+			assertEquals(new Cuboid(ORIGIN, 1, 2, 3), new Cuboid(ORIGIN, new BlockPos(1, 2, 3)));
+		}
+	}
+
+	@Nested
+	@DisplayName("equals/hashCode contract")
+	class EqualsHashCode {
+
+		@Test
+		@DisplayName("equal cuboids hash equally")
+		void equalCuboidsHashEqually() {
+			Cuboid one = new Cuboid(ORIGIN, 1, 2, 3);
+			Cuboid other = new Cuboid(ORIGIN, 1, 2, 3);
+
+			assertEquals(one, other);
+			assertEquals(one.hashCode(), other.hashCode(), "equal cuboids hashed differently");
+		}
+
+		/**
+		 * The bug this guards: {@code equals} without {@code hashCode} makes every hash-based
+		 * lookup miss, which is how the design cache silently stopped caching.
+		 */
+		@Test
+		@DisplayName("an equal cuboid finds an entry keyed by another")
+		void worksAsAHashMapKey() {
+			Map<Cuboid, String> byBounds = new HashMap<>();
+			byBounds.put(new Cuboid(ORIGIN, 1, 2, 3), "design");
+
+			assertEquals("design", byBounds.get(new Cuboid(ORIGIN, 1, 2, 3)),
+				"an equal key did not find its entry");
+			assertEquals(1, new HashSet<>(java.util.List.of(new Cuboid(ORIGIN, 1, 2, 3),
+				new Cuboid(ORIGIN, 1, 2, 3))).size(), "equal cuboids did not collapse in a Set");
+		}
+
+		@Test
+		@DisplayName("each dimension participates in the hash")
+		void everyDimensionParticipates() {
+			Cuboid base = new Cuboid(BlockPos.ZERO, 1, 2, 3);
+			Set<Integer> hashes = new HashSet<>();
+			hashes.add(base.hashCode());
+			hashes.add(new Cuboid(new BlockPos(1, 0, 0), 1, 2, 3).hashCode());
+			hashes.add(new Cuboid(new BlockPos(0, 1, 0), 1, 2, 3).hashCode());
+			hashes.add(new Cuboid(new BlockPos(0, 0, 1), 1, 2, 3).hashCode());
+			hashes.add(new Cuboid(BlockPos.ZERO, 9, 2, 3).hashCode());
+			hashes.add(new Cuboid(BlockPos.ZERO, 1, 9, 3).hashCode());
+			hashes.add(new Cuboid(BlockPos.ZERO, 1, 2, 9).hashCode());
+
+			assertEquals(7, hashes.size(), "two cuboids differing in one dimension shared a hash");
+		}
+
+		@Test
+		@DisplayName("differing cuboids are not equal")
+		void differingCuboidsAreNotEqual() {
+			Cuboid base = new Cuboid(ORIGIN, 1, 2, 3);
+
+			assertFalse(base.equals(new Cuboid(ORIGIN, 1, 2, 4)));
+			assertFalse(base.equals(new Cuboid(BlockPos.ZERO, 1, 2, 3)));
+			assertFalse(base.equals(null));
+			assertFalse(base.equals("not a cuboid"));
+		}
+
+		/**
+		 * A Cuboid is mutable and moved in place by the planner tools, so its hash moves with it -
+		 * which is why anything keying a map on one is keyed on identity. Pinning that here so the
+		 * constraint is visible rather than folklore.
+		 */
+		@Test
+		@DisplayName("moving one changes its hash, so map keys are identity keys")
+		void mutationChangesTheHash() {
+			Cuboid cuboid = new Cuboid(ORIGIN, 1, 2, 3);
+			int before = cuboid.hashCode();
+			cuboid.move(1, 0, 0);
+
+			assertFalse(before == cuboid.hashCode(), "moving a cuboid left its hash unchanged");
+		}
+	}
+
+	@Nested
+	@DisplayName("containment and intersection")
+	class Geometry {
+
+		@Test
+		@DisplayName("contains is inclusive at the origin and exclusive at the far corner")
+		void containsIsHalfOpen() {
+			Cuboid cuboid = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+
+			assertTrue(cuboid.contains(BlockPos.ZERO));
+			assertTrue(cuboid.contains(new BlockPos(1, 1, 1)));
+			assertFalse(cuboid.contains(new BlockPos(2, 1, 1)));
+			assertFalse(cuboid.contains(new BlockPos(1, 2, 1)));
+			assertFalse(cuboid.contains(new BlockPos(1, 1, 2)));
+			assertFalse(cuboid.contains(new BlockPos(-1, 0, 0)));
+		}
+
+		/** Intersection is deliberately horizontal only - stacks are allowed to sit on each other. */
+		@Test
+		@DisplayName("intersects ignores height")
+		void intersectsIgnoresHeight() {
+			Cuboid ground = new Cuboid(BlockPos.ZERO, 4, 4, 4);
+			Cuboid above = new Cuboid(new BlockPos(0, 100, 0), 4, 4, 4);
+			Cuboid beside = new Cuboid(new BlockPos(4, 0, 0), 4, 4, 4);
+			Cuboid overlapping = new Cuboid(new BlockPos(3, 0, 3), 4, 4, 4);
+
+			assertTrue(ground.intersects(above), "vertically separated cuboids should still intersect");
+			assertFalse(ground.intersects(beside), "cuboids sharing only a face should not intersect");
+			assertTrue(ground.intersects(overlapping));
+			assertTrue(overlapping.intersects(ground), "intersects is not symmetric");
+		}
+
+		@Test
+		@DisplayName("getCenter offsets by half the size")
+		void centre() {
+			assertEquals(new BlockPos(1, 2, 3), new Cuboid(BlockPos.ZERO, 2, 4, 6).getCenter());
+			assertEquals(new BlockPos(5, 7, 9), new Cuboid(ORIGIN, 3, 5, 7).getCenter());
+		}
+
+		@Test
+		@DisplayName("centerHorizontallyOn keeps the y of the target")
+		void centerHorizontally() {
+			Cuboid cuboid = new Cuboid(BlockPos.ZERO, 4, 3, 6);
+			cuboid.centerHorizontallyOn(new BlockPos(10, 20, 30));
+
+			assertEquals(new BlockPos(8, 20, 27), cuboid.getOrigin());
+			assertEquals(new BlockPos(4, 3, 6), cuboid.getSize(), "centering changed the size");
+		}
+
+		@Test
+		@DisplayName("move translates without resizing")
+		void move() {
+			Cuboid cuboid = new Cuboid(ORIGIN, 1, 2, 3);
+			cuboid.move(-1, 2, -3);
+
+			assertEquals(new BlockPos(3, 7, 3), cuboid.getOrigin());
+			assertEquals(new BlockPos(1, 2, 3), cuboid.getSize());
+		}
+
+		@Test
+		@DisplayName("clone is an equal but separate cuboid")
+		void cloneIsIndependent() {
+			Cuboid cuboid = new Cuboid(ORIGIN, 1, 2, 3);
+			Cuboid clone = cuboid.clone();
+
+			assertEquals(cuboid, clone);
+			assertNotSame(cuboid, clone);
+
+			clone.move(100, 0, 0);
+			assertEquals(ORIGIN, cuboid.getOrigin(), "moving the clone moved the original");
+		}
+	}
+
+	@Nested
+	@DisplayName("moveToAttach")
+	class Attachment {
+
+		private Room neighbour() {
+			return new Room(new BlockPos(0, 0, 0), 6, 4, 8);
+		}
+
+		@Test
+		@DisplayName("WEST puts this cuboid on the neighbour's far x face")
+		void west() {
+			Cuboid attached = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			attached.moveToAttach(neighbour(), Direction.WEST, 0);
+
+			assertEquals(6, attached.getOrigin()
+				.getX());
+			assertEquals(3, attached.getOrigin()
+				.getZ(), "attaching sideways should centre on the neighbour's z");
+		}
+
+		@Test
+		@DisplayName("EAST puts this cuboid before the neighbour's origin")
+		void east() {
+			Cuboid attached = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			attached.moveToAttach(neighbour(), Direction.EAST, 0);
+
+			assertEquals(-2, attached.getOrigin()
+				.getX());
+		}
+
+		@Test
+		@DisplayName("NORTH and SOUTH attach along z and centre along x")
+		void northSouth() {
+			Cuboid north = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			north.moveToAttach(neighbour(), Direction.NORTH, 0);
+			assertEquals(-2, north.getOrigin()
+				.getZ());
+			assertEquals(2, north.getOrigin()
+				.getX(), "attaching along z should centre on the neighbour's x");
+
+			Cuboid south = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			south.moveToAttach(neighbour(), Direction.SOUTH, 0);
+			assertEquals(8, south.getOrigin()
+				.getZ());
+		}
+
+		@Test
+		@DisplayName("UP and DOWN stack vertically and centre on both horizontal axes")
+		void upDown() {
+			Cuboid up = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			up.moveToAttach(neighbour(), Direction.UP, 0);
+			assertEquals(new BlockPos(2, 4, 3), up.getOrigin());
+
+			Cuboid down = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			down.moveToAttach(neighbour(), Direction.DOWN, 0);
+			assertEquals(new BlockPos(2, -2, 3), down.getOrigin());
+		}
+
+		@Test
+		@DisplayName("the shift argument slides the centred axes")
+		void shiftSlidesTheCentredAxes() {
+			Cuboid unshifted = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			unshifted.moveToAttach(neighbour(), Direction.WEST, 0);
+
+			Cuboid shifted = new Cuboid(BlockPos.ZERO, 2, 2, 2);
+			shifted.moveToAttach(neighbour(), Direction.WEST, 3);
+
+			assertEquals(unshifted.getOrigin()
+				.getZ() + 3,
+				shifted.getOrigin()
+					.getZ());
+			assertEquals(unshifted.getOrigin()
+				.getX(),
+				shifted.getOrigin()
+					.getX(), "the attached axis should not be shifted");
+		}
+	}
+
+	@Nested
+	@DisplayName("Room")
+	class RoomBehaviour {
+
+		@Test
+		@DisplayName("getInterior insets by one on x and z and keeps the height")
+		void interiorIsInsetByOne() {
+			Room room = new Room(new BlockPos(0, 0, 0), 6, 4, 8);
+			Room interior = room.getInterior();
+
+			assertEquals(new BlockPos(1, 0, 1), interior.getOrigin());
+			assertEquals(new BlockPos(4, 4, 6), interior.getSize());
+		}
+
+		@Test
+		@DisplayName("stack sits on top and clears the roof of the room below")
+		void stackSitsOnTop() {
+			// Square on purpose: quadFacadeRoof is true only for a square footprint, so a
+			// rectangular fixture would assert that stack() cleared a flag that was never set.
+			Room room = new Room(new BlockPos(0, 0, 0), 6, 4, 6);
+			Room stacked = room.stack(false);
+
+			assertEquals(4, stacked.getOrigin()
+				.getY());
+			assertEquals(com.timmie.mightyarchitect.control.design.DesignType.NONE, room.roofType,
+				"stacking should clear the lower room's roof");
+			assertFalse(room.quadFacadeRoof, "stacking should clear the lower room's quad facade roof");
+		}
+
+		@Test
+		@DisplayName("a non-exact stack is at least four blocks tall")
+		void stackHasAMinimumHeight() {
+			Room shallow = new Room(new BlockPos(0, 0, 0), 6, 2, 8);
+
+			assertEquals(4, shallow.stack(false).height);
+			assertEquals(2, new Room(new BlockPos(0, 0, 0), 6, 2, 8).stack(true).height);
+		}
+
+		@Test
+		@DisplayName("orientation follows the longer horizontal axis")
+		void orientation() {
+			assertSame(Direction.Axis.X, new Room(BlockPos.ZERO, 8, 4, 4).getOrientation());
+			assertSame(Direction.Axis.Z, new Room(BlockPos.ZERO, 4, 4, 8).getOrientation());
+			assertSame(Direction.Axis.Z, new Room(BlockPos.ZERO, 4, 4, 4).getOrientation(),
+				"a square room should not flip orientation between builds");
+		}
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/DesignExporterFilenameTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/DesignExporterFilenameTest.java
@@ -1,0 +1,99 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.design.DesignExporter;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The name on line two of a design's sign becomes the file that design is saved as. Before the
+ * P1 fixes this returned a Java object dump ({@code SignText@6f1a2b}) on every version from 1.20
+ * onwards, which meant sign-naming was dead, the garbage name was written back to the sign, and
+ * re-exporting a design orphaned the old file instead of overwriting it.
+ * <p>
+ * Idempotence is the property that makes re-export overwrite rather than orphan, and it is pure
+ * string arithmetic - exactly what should not need a game boot to check.
+ */
+@Bootstrapped
+@DisplayName("DesignExporter.designFilename")
+class DesignExporterFilenameTest {
+
+	@Test
+	@DisplayName("derives a filename from sign text")
+	void derivesFromSignText() {
+		assertEquals("my_design.json", DesignExporter.designFilename("My Design"));
+	}
+
+	@Test
+	@DisplayName("is idempotent, so re-export overwrites rather than orphaning")
+	void isIdempotent() {
+		String once = DesignExporter.designFilename("My Design");
+		String twice = DesignExporter.designFilename(once);
+		String thrice = DesignExporter.designFilename(twice);
+
+		assertEquals("my_design.json", once);
+		assertEquals(once, twice, "a second pass grew another suffix");
+		assertEquals(once, thrice, "a third pass grew another suffix");
+	}
+
+	@Test
+	@DisplayName("strips the extension case-insensitively")
+	void stripsExtensionCaseInsensitively() {
+		assertEquals("my_design.json", DesignExporter.designFilename("My Design.JSON"));
+		assertEquals("my_design.json", DesignExporter.designFilename("my_design.Json"));
+	}
+
+	@Test
+	@DisplayName("blank sign text yields nothing, so the caller falls back to an indexed name")
+	void blankSignTextYieldsNothing() {
+		assertTrue(DesignExporter.designFilename("   ")
+			.isEmpty());
+		assertTrue(DesignExporter.designFilename("")
+			.isEmpty());
+		assertTrue(DesignExporter.designFilename(".json")
+			.isEmpty());
+		assertTrue(DesignExporter.designFilename("!!!")
+			.isEmpty());
+	}
+
+	@TestFactory
+	@DisplayName("cannot escape the design folder")
+	Stream<DynamicTest> cannotEscapeItsFolder() {
+		List<String> hostile = List.of("../../evil name", "..", "../../../design.json", "/tmp/design",
+			"C:\\design.json", "a/b/c");
+
+		return hostile.stream()
+			.map(name -> DynamicTest.dynamicTest("\"" + name + "\"", () -> {
+				String filename = DesignExporter.designFilename(name);
+
+				assertFalse(filename.contains("/"), () -> "kept a forward slash: " + filename);
+				assertFalse(filename.contains("\\"), () -> "kept a backslash: " + filename);
+				assertFalse(filename.contains(".."), () -> "kept a parent reference: " + filename);
+				assertTrue(filename.isEmpty() || filename.endsWith(".json"),
+					() -> "produced something that is not a design file: " + filename);
+			}));
+	}
+
+	/**
+	 * The exported name is echoed back onto the sign, so whatever comes out has to survive being
+	 * read back in. A name that changed on every pass is what orphaned the previous file.
+	 */
+	@Test
+	@DisplayName("a derived name survives a round trip through the sign")
+	void survivesTheSignRoundTrip() {
+		for (String signed : List.of("Gothic Window", "gothic_window.json", "  Gothic-Window  ", "Roof 2")) {
+			String filename = DesignExporter.designFilename(signed);
+			assertEquals(filename, DesignExporter.designFilename(filename),
+				"\"" + signed + "\" did not survive being written back to the sign");
+		}
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/DesignThemeTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/DesignThemeTest.java
@@ -1,0 +1,209 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.design.DesignLayer;
+import com.timmie.mightyarchitect.control.design.DesignTheme;
+import com.timmie.mightyarchitect.control.design.DesignType;
+import com.timmie.mightyarchitect.control.design.ThemeStorage;
+import com.timmie.mightyarchitect.control.palette.Palette;
+import com.timmie.mightyarchitect.control.palette.PaletteDefinition;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.ListTag;
+import net.minecraft.nbt.StringTag;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Theme deserialization and creation. A theme file can be written by hand or by a newer build, so
+ * it can name a layer or type this build does not have; {@code valueOf} threw for that, and the
+ * throw escaped the single try block around the whole theme-directory scan - one such file emptied
+ * the entire theme list instead of costing that theme one layer.
+ */
+@Bootstrapped
+@DisplayName("DesignTheme")
+class DesignThemeTest {
+
+	private static CompoundTag themeTag(List<String> layers, List<String> types) {
+		ListTag layerTags = new ListTag();
+		layers.forEach(name -> layerTags.add(StringTag.valueOf(name)));
+		ListTag typeTags = new ListTag();
+		types.forEach(name -> typeTags.add(StringTag.valueOf(name)));
+
+		CompoundTag tag = new CompoundTag();
+		tag.putString("Name", "Unit Test Theme");
+		tag.putString("Designer", "unit-test");
+		tag.put("Layers", layerTags);
+		tag.put("Types", typeTags);
+		return tag;
+	}
+
+	@Nested
+	@DisplayName("fromNBT")
+	class FromNbt {
+
+		@Test
+		@DisplayName("reads the name, designer, layers and types")
+		void readsTheBasics() {
+			DesignTheme theme = DesignTheme.fromNBT(themeTag(List.of("Regular", "Roofing"), List.of("WALL", "ROOF")));
+
+			assertEquals("Unit Test Theme", theme.getDisplayName());
+			assertEquals("unit-test", theme.getDesigner());
+			assertEquals(List.of(DesignLayer.Regular, DesignLayer.Roofing), theme.getLayers());
+			assertEquals(List.of(DesignType.WALL, DesignType.ROOF), theme.getTypes());
+		}
+
+		@Test
+		@DisplayName("skips an unknown layer instead of throwing")
+		void skipsUnknownLayer() {
+			DesignTheme theme = DesignTheme.fromNBT(
+				themeTag(List.of("Regular", "NotALayerThisBuildKnows"), List.of()));
+
+			assertEquals(List.of(DesignLayer.Regular), theme.getLayers());
+		}
+
+		@Test
+		@DisplayName("skips an unknown type instead of throwing")
+		void skipsUnknownType() {
+			DesignTheme theme = DesignTheme.fromNBT(
+				themeTag(List.of(), List.of("WALL", "PORTCULLIS_FROM_THE_FUTURE")));
+
+			assertEquals(List.of(DesignType.WALL), theme.getTypes());
+		}
+
+		/** The regression itself: one bad name must cost one entry, not the whole list. */
+		@Test
+		@DisplayName("one unknown name does not empty the list")
+		void oneUnknownNameDoesNotEmptyTheList() {
+			DesignTheme theme = DesignTheme.fromNBT(themeTag(
+				List.of("Foundation", "TypoLayer", "Regular", "Roofing"),
+				List.of("WALL", "TypoType", "CORNER", "ROOF")));
+
+			assertEquals(List.of(DesignLayer.Foundation, DesignLayer.Regular, DesignLayer.Roofing),
+				theme.getLayers());
+			assertEquals(List.of(DesignType.WALL, DesignType.CORNER, DesignType.ROOF), theme.getTypes());
+		}
+
+		@Test
+		@DisplayName("a null tag yields null rather than throwing")
+		void nullTagYieldsNull() {
+			assertNull(DesignTheme.fromNBT(null));
+		}
+
+		@Test
+		@DisplayName("an empty tag yields an empty but usable theme")
+		void emptyTagYieldsAnEmptyTheme() {
+			DesignTheme theme = DesignTheme.fromNBT(new CompoundTag());
+
+			assertTrue(theme.getLayers()
+				.isEmpty());
+			assertTrue(theme.getTypes()
+				.isEmpty());
+			assertEquals(10, theme.getMaxFloorHeight(), "an absent room height should keep the default");
+		}
+
+		@Test
+		@DisplayName("room layers exclude roofing")
+		void roomLayersExcludeRoofing() {
+			DesignTheme theme = DesignTheme.fromNBT(
+				themeTag(List.of("Regular", "Roofing", "Foundation"), List.of()));
+
+			assertEquals(List.of(DesignLayer.Regular, DesignLayer.Foundation), theme.getRoomLayers());
+		}
+
+		@Test
+		@DisplayName("survives a round trip through asTagCompound")
+		void survivesARoundTrip() {
+			DesignTheme original = DesignTheme.fromNBT(
+				themeTag(List.of("Regular", "Roofing"), List.of("WALL", "ROOF")));
+			original.setMaxFloorHeight(7);
+
+			DesignTheme roundTrip = DesignTheme.fromNBT(original.asTagCompound());
+
+			assertEquals(original.getDisplayName(), roundTrip.getDisplayName());
+			assertEquals(original.getDesigner(), roundTrip.getDesigner());
+			assertEquals(original.getLayers(), roundTrip.getLayers());
+			assertEquals(original.getTypes(), roundTrip.getTypes());
+			assertEquals(7, roundTrip.getMaxFloorHeight());
+		}
+	}
+
+	@Nested
+	@DisplayName("ThemeStorage.createTheme")
+	class CreateTheme {
+
+		@Test
+		@DisplayName("gives every new theme its own two palettes")
+		void newThemesGetTheirOwnPalettes() {
+			PaletteDefinition shared = PaletteDefinition.defaultPalette();
+			DesignTheme created = ThemeStorage.createTheme("Unit Test Theme", "unit-test");
+
+			assertNotSame(shared, created.getDefaultPalette(),
+				"a new theme aliased the shared default palette");
+			assertNotSame(shared, created.getDefaultSecondaryPalette(),
+				"a new theme aliased the shared default palette as its secondary");
+			assertNotSame(created.getDefaultPalette(), created.getDefaultSecondaryPalette(),
+				"a new theme's two palettes are the same object");
+		}
+
+		@Test
+		@DisplayName("editing a new theme's palette leaves the default alone")
+		void editingLeavesTheDefaultAlone() {
+			PaletteDefinition shared = PaletteDefinition.defaultPalette();
+			BlockState before = shared.get(Palette.ROOF_PRIMARY);
+
+			DesignTheme created = ThemeStorage.createTheme("Unit Test Theme", "unit-test");
+			created.getDefaultPalette()
+				.put(Palette.ROOF_PRIMARY, Blocks.GOLD_BLOCK);
+
+			assertEquals(before, shared.get(Palette.ROOF_PRIMARY),
+				"editing a theme palette rewrote the shared default");
+			assertEquals(before, created.getDefaultSecondaryPalette()
+				.get(Palette.ROOF_PRIMARY), "editing the primary palette reached the secondary");
+		}
+
+		@Test
+		@DisplayName("the file path is one sanitized folder name")
+		void filePathIsOneSanitizedFolderName() {
+			DesignTheme created = ThemeStorage.createTheme("../../Evil Theme", "unit-test");
+			String path = created.getFilePath();
+
+			assertFalse(path.isEmpty());
+			assertFalse(path.contains("/"), () -> "theme folder kept a slash: " + path);
+			assertFalse(path.contains("\\"), () -> "theme folder kept a backslash: " + path);
+			assertFalse(path.contains(".."), () -> "theme folder kept a parent reference: " + path);
+		}
+
+		@Test
+		@DisplayName("a name that sanitizes away still gets a usable folder")
+		void unusableNameStillGetsAFolder() {
+			assertEquals("my_theme", ThemeStorage.createTheme("///", "unit-test")
+				.getFilePath());
+			assertEquals("my_theme", ThemeStorage.createTheme("", "unit-test")
+				.getFilePath(), "an empty name should become the default theme name");
+		}
+
+		@Test
+		@DisplayName("a new theme is marked imported and starts with the standard layers and types")
+		void newThemeShape() {
+			DesignTheme created = ThemeStorage.createTheme("Unit Test Theme", "unit-test");
+
+			assertTrue(created.isImported());
+			assertEquals("unit-test", created.getDesigner());
+			assertEquals(List.of(DesignLayer.Regular, DesignLayer.Roofing, DesignLayer.Foundation),
+				created.getLayers());
+			assertEquals(List.of(DesignType.WALL, DesignType.CORNER, DesignType.ROOF, DesignType.FACADE,
+				DesignType.FLAT_ROOF), created.getTypes());
+		}
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/FilesHelperSlugTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/FilesHelperSlugTest.java
@@ -1,0 +1,143 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.foundation.utility.FilesHelper;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code FilesHelper.slug} is the mod's only defence against a user-supplied name reaching the
+ * filesystem: theme names, palette names and design sign text are all pasted straight into a path.
+ * It is pure {@code String} arithmetic, so it belongs here rather than costing a game boot on 25
+ * targets to check.
+ */
+@Bootstrapped
+@DisplayName("FilesHelper.slug")
+class FilesHelperSlugTest {
+
+	/**
+	 * Names that must not be able to address anything outside the folder they are joined to. Sign
+	 * text is attacker-adjacent - it is whatever another player wrote on a sign in a shared world.
+	 */
+	private static final List<String> HOSTILE_NAMES = List.of(
+		"../../evil name",
+		"..",
+		"../",
+		"..\\..\\evil",
+		"/etc/passwd",
+		"C:\\Windows\\System32",
+		"nested/path/name",
+		"name\u0000truncated",
+		"....//....//x",
+		"~/.ssh/authorized_keys");
+
+	@Test
+	@DisplayName("lower-cases and keeps the safe alphabet")
+	void keepsSafeCharacters() {
+		assertEquals("medieval_tower2", FilesHelper.slug("Medieval_Tower2"));
+	}
+
+	@Test
+	@DisplayName("spaces, dashes and dots become underscores")
+	void convertsSeparators() {
+		assertEquals("town_house", FilesHelper.slug("Town House"));
+		assertEquals("town_house", FilesHelper.slug("Town-House"));
+		assertEquals("town_house", FilesHelper.slug("Town.House"));
+	}
+
+	@Test
+	@DisplayName("drops everything else instead of escaping it")
+	void dropsUnsafeCharacters() {
+		assertEquals("cattinghams_palace", FilesHelper.slug("Cattingham's Palace!"));
+		// Only space, dash and dot map to an underscore; a drive colon and a backslash are simply
+		// gone, which is why the result runs together rather than keeping a separator.
+		assertEquals("cwindows", FilesHelper.slug("C:\\Windows"));
+	}
+
+	/**
+	 * The property that matters, stated as a property rather than as expected output: whatever
+	 * comes out is one path element that resolves inside the folder it is joined to.
+	 */
+	@TestFactory
+	@DisplayName("cannot escape its folder")
+	Stream<DynamicTest> cannotEscapeItsFolder() {
+		Path base = Paths.get("themes")
+			.toAbsolutePath()
+			.normalize();
+
+		return HOSTILE_NAMES.stream()
+			.map(hostile -> DynamicTest.dynamicTest(quoted(hostile), () -> {
+				String slug = FilesHelper.slug(hostile);
+
+				assertFalse(slug.contains("/"), () -> "slug kept a forward slash: " + slug);
+				assertFalse(slug.contains("\\"), () -> "slug kept a backslash: " + slug);
+				assertFalse(slug.contains(".."), () -> "slug kept a parent reference: " + slug);
+				assertFalse(slug.contains("\u0000"), () -> "slug kept a NUL byte: " + slug);
+
+				Path resolved = base.resolve(slug.isEmpty() ? "unnamed" : slug)
+					.normalize();
+				assertTrue(resolved.startsWith(base),
+					() -> quoted(hostile) + " resolved outside the folder: " + resolved);
+				assertEquals(1, base.relativize(resolved)
+					.getNameCount(),
+					() -> quoted(hostile) + " produced more than one path element: " + resolved);
+			}));
+	}
+
+	@Test
+	@DisplayName("sanitizes away to empty rather than to a dangerous default")
+	void sanitizesAwayToEmpty() {
+		assertEquals("", FilesHelper.slug("   "));
+		assertEquals("", FilesHelper.slug("..."));
+		assertEquals("", FilesHelper.slug("!!!"));
+		assertEquals("", FilesHelper.slug(""));
+	}
+
+	@Test
+	@DisplayName("trims leading and trailing underscores")
+	void trimsUnderscores() {
+		assertEquals("name", FilesHelper.slug("  name  "));
+		assertEquals("name", FilesHelper.slug("___name___"));
+		assertEquals("a_b", FilesHelper.slug("-a b-"));
+	}
+
+	@Test
+	@DisplayName("caps the length so a long name cannot overflow a path")
+	void capsLength() {
+		assertEquals(64, FilesHelper.slug("a".repeat(500))
+			.length());
+	}
+
+	/** Windows refuses these as filenames with or without an extension, so they get a suffix. */
+	@TestFactory
+	@DisplayName("escapes Windows reserved device names")
+	Stream<DynamicTest> escapesWindowsReservedNames() {
+		return Stream.of("con", "PRN", "aux", "NUL", "com1", "lpt9")
+			.map(reserved -> DynamicTest.dynamicTest(reserved,
+				() -> assertEquals(reserved.toLowerCase(Locale.ROOT) + "_", FilesHelper.slug(reserved))));
+	}
+
+	@Test
+	@DisplayName("slugOr substitutes the fallback only when nothing survived")
+	void slugOrFallsBack() {
+		assertEquals("unnamed", FilesHelper.slugOr("///", "unnamed"));
+		assertEquals("my_theme", FilesHelper.slugOr("", "my_theme"));
+		assertEquals("kept", FilesHelper.slugOr("Kept", "my_theme"));
+	}
+
+	private static String quoted(String value) {
+		return "\"" + value.replace("\u0000", "\\0") + "\"";
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/HarnessSmokeTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/HarnessSmokeTest.java
@@ -1,0 +1,32 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.compose.Cuboid;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Blocks;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Proves the harness itself works before anything relies on it: the mod's classes load, and
+ * Minecraft's registries are usable.
+ */
+@Bootstrapped
+@DisplayName("harness")
+class HarnessSmokeTest {
+
+	@Test
+	@DisplayName("Minecraft's block registry is bootstrapped")
+	void registriesAreUsable() {
+		assertNotNull(Blocks.STONE.defaultBlockState(), "Blocks.STONE has no default state");
+	}
+
+	@Test
+	@DisplayName("the mod's own classes load")
+	void modClassesLoad() {
+		assertEquals(new BlockPos(1, 2, 3), new Cuboid(new BlockPos(1, 2, 3), 1, 1, 1).getOrigin());
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/InstantPrintPacketChunkingTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/InstantPrintPacketChunkingTest.java
@@ -1,0 +1,183 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.networking.InstantPrintPacket;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Printing a building sends its blocks to the server split across many packets. The split is the
+ * only thing standing between a large build and a payload the connection refuses, and the same
+ * bound is what the decoder trusts on the way in - a packet declaring more blocks than
+ * {@link InstantPrintPacket#MAX_BLOCKS_PER_PACKET} is refused, so a sender that ever exceeded it
+ * would silently fail to print.
+ * <p>
+ * The server-test companion already drives this against a real level, but only asserts that the
+ * split happened at all. The arithmetic itself - how many packets, which blocks in them, where the
+ * anchor lands - is pure, and asserting it here costs milliseconds instead of a dedicated server
+ * on 25 targets.
+ */
+@Bootstrapped
+@DisplayName("InstantPrintPacket.sendSchematic")
+class InstantPrintPacketChunkingTest {
+
+	private static final int MAX = InstantPrintPacket.MAX_BLOCKS_PER_PACKET;
+	private static final BlockPos ANCHOR = new BlockPos(100, 64, -200);
+
+	/** A schematic of {@code count} distinct positions, each carrying a distinguishable state. */
+	private static Map<BlockPos, BlockState> schematic(int count) {
+		BlockState[] palette = { Blocks.STONE.defaultBlockState(), Blocks.OAK_PLANKS.defaultBlockState(),
+			Blocks.GLASS.defaultBlockState() };
+
+		Map<BlockPos, BlockState> blocks = new LinkedHashMap<>();
+		for (int i = 0; i < count; i++)
+			blocks.put(new BlockPos(i % 16, i / 256, (i / 16) % 16), palette[i % palette.length]);
+		return blocks;
+	}
+
+	private static Map<BlockPos, BlockState> flatten(List<InstantPrintPacket> packets) {
+		Map<BlockPos, BlockState> all = new HashMap<>();
+		packets.forEach(packet -> all.putAll(packet.blocks()));
+		return all;
+	}
+
+	@Test
+	@DisplayName("the bound is positive, so a build can actually be split")
+	void theBoundIsUsable() {
+		assertTrue(MAX > 0, "MAX_BLOCKS_PER_PACKET must be positive");
+	}
+
+	@Test
+	@DisplayName("an empty schematic still yields one packet")
+	void emptySchematicYieldsOnePacket() {
+		List<InstantPrintPacket> packets = InstantPrintPacket.sendSchematic(Map.of(), ANCHOR);
+
+		assertEquals(1, packets.size());
+		assertTrue(packets.get(0)
+			.blocks()
+			.isEmpty());
+	}
+
+	@Test
+	@DisplayName("a schematic that fits stays in one packet")
+	void schematicThatFitsStaysInOnePacket() {
+		List<InstantPrintPacket> packets = InstantPrintPacket.sendSchematic(schematic(MAX), ANCHOR);
+
+		assertEquals(1, packets.size());
+		assertEquals(MAX, packets.get(0)
+			.size());
+	}
+
+	@Test
+	@DisplayName("one block past the bound needs a second packet")
+	void oneBlockPastTheBoundSplits() {
+		List<InstantPrintPacket> packets = InstantPrintPacket.sendSchematic(schematic(MAX + 1), ANCHOR);
+
+		assertEquals(2, packets.size());
+		assertEquals(MAX, packets.get(0)
+			.size());
+		assertEquals(1, packets.get(1)
+			.size());
+	}
+
+	/**
+	 * The bound is what the decoder enforces, so a sender that overshot it by one would have every
+	 * such packet rejected on arrival - a print that silently does nothing.
+	 */
+	@TestFactory
+	@DisplayName("no packet ever exceeds the bound the decoder enforces")
+	Stream<DynamicTest> noPacketExceedsTheBound() {
+		return Stream.of(0, 1, MAX - 1, MAX, MAX + 1, MAX * 3, MAX * 3 + 1, 1000)
+			.map(count -> DynamicTest.dynamicTest(count + " blocks", () -> {
+				List<InstantPrintPacket> packets = InstantPrintPacket.sendSchematic(schematic(count), ANCHOR);
+
+				for (InstantPrintPacket packet : packets) {
+					assertTrue(packet.size() <= MAX,
+						() -> "a packet carried " + packet.size() + " blocks, past the limit of " + MAX);
+					assertEquals(packet.blocks()
+						.size(), packet.size(), "the declared size disagreed with the payload");
+				}
+
+				assertEquals(Math.max(1, (int) Math.ceil(count / (double) MAX)), packets.size(),
+					"unexpected packet count for " + count + " blocks");
+			}));
+	}
+
+	@Test
+	@DisplayName("every block survives the split exactly once")
+	void everyBlockSurvivesExactlyOnce() {
+		Map<BlockPos, BlockState> source = schematic(MAX * 4 + 7);
+		List<InstantPrintPacket> packets = InstantPrintPacket.sendSchematic(source, ANCHOR);
+
+		int totalSent = packets.stream()
+			.mapToInt(InstantPrintPacket::size)
+			.sum();
+		assertEquals(source.size(), totalSent, "the split lost or duplicated blocks");
+
+		Map<BlockPos, BlockState> flattened = flatten(packets);
+		assertEquals(source.size(), flattened.size(), "two packets carried the same position");
+
+		source.forEach((local, state) -> assertEquals(state, flattened.get(local.offset(ANCHOR)),
+			() -> "the block at " + local + " did not arrive at its anchored position"));
+	}
+
+	@Test
+	@DisplayName("packets do not overlap")
+	void packetsDoNotOverlap() {
+		List<InstantPrintPacket> packets = InstantPrintPacket.sendSchematic(schematic(MAX * 3), ANCHOR);
+
+		Set<BlockPos> seen = new HashSet<>();
+		for (InstantPrintPacket packet : packets)
+			for (BlockPos pos : packet.blocks()
+				.keySet())
+				assertTrue(seen.add(pos), () -> "position " + pos + " appeared in two packets");
+	}
+
+	@Test
+	@DisplayName("the anchor is applied once, not twice")
+	void anchorIsAppliedOnce() {
+		Map<BlockPos, BlockState> source = Map.of(new BlockPos(1, 2, 3), Blocks.STONE.defaultBlockState());
+
+		Map<BlockPos, BlockState> sent = flatten(InstantPrintPacket.sendSchematic(source, ANCHOR));
+
+		assertTrue(sent.containsKey(new BlockPos(101, 66, -197)),
+			() -> "expected the anchored position, got " + sent.keySet());
+		assertFalse(sent.containsKey(new BlockPos(1, 2, 3)), "the block was sent at its local position");
+	}
+
+	@Test
+	@DisplayName("a zero anchor leaves positions where they were")
+	void zeroAnchorIsIdentity() {
+		Map<BlockPos, BlockState> source = schematic(MAX + 5);
+
+		assertEquals(source, flatten(InstantPrintPacket.sendSchematic(source, BlockPos.ZERO)));
+	}
+
+	@Test
+	@DisplayName("sending does not mutate the schematic it was given")
+	void doesNotMutateItsInput() {
+		Map<BlockPos, BlockState> source = schematic(MAX * 2 + 3);
+		Map<BlockPos, BlockState> before = new LinkedHashMap<>(source);
+
+		InstantPrintPacket.sendSchematic(source, ANCHOR);
+
+		assertEquals(before, source, "sendSchematic modified the caller's schematic");
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/MinecraftBootstrap.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/MinecraftBootstrap.java
@@ -1,0 +1,51 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Boots enough of Minecraft for the mod's pure logic to run outside the game.
+ * <p>
+ * Anything touching {@code Blocks}, a {@code BlockState} or NBT block-state serialization reaches
+ * {@code BuiltInRegistries}, whose static initializer throws {@code ExceptionInInitializerError}
+ * until the registries are frozen. Two calls fix that, and they are the same two on every
+ * Minecraft version in the matrix - {@code SharedConstants.tryDetectVersion()} and
+ * {@code Bootstrap.bootStrap()} are byte-identical from 1.19.4 through 26.2 (verified with javap
+ * against every node's jar), so this class needs no Stonecutter guard and can live in the
+ * version-agnostic test module.
+ * <p>
+ * Bootstrapping costs a few seconds and is process-global, so it happens once per JVM rather than
+ * once per test class.
+ */
+public final class MinecraftBootstrap implements BeforeAllCallback {
+
+	/** Applies the bootstrap to a test class. */
+	@Target(ElementType.TYPE)
+	@Retention(RetentionPolicy.RUNTIME)
+	@ExtendWith(MinecraftBootstrap.class)
+	public @interface Bootstrapped {
+	}
+
+	private static boolean booted;
+
+	@Override
+	public void beforeAll(ExtensionContext context) {
+		ensureBooted();
+	}
+
+	public static synchronized void ensureBooted() {
+		if (booted)
+			return;
+		SharedConstants.tryDetectVersion();
+		Bootstrap.bootStrap();
+		booted = true;
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/PaletteDefinitionTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/PaletteDefinitionTest.java
@@ -1,0 +1,154 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.palette.Palette;
+import com.timmie.mightyarchitect.control.palette.PaletteDefinition;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * The default palette is a shared mutable singleton every other palette starts from, so anything
+ * that stores it has to clone first - otherwise recolouring one theme silently recolours the
+ * starting palette of every theme made afterwards. That aliasing bug shipped for years.
+ * <p>
+ * Also covers the fix that let palettes load outside a world: reading blocks through
+ * {@code Minecraft.getInstance().level} NPE'd on the title screen, so it now goes through
+ * {@code BuiltInRegistries} - which is exactly why these assertions can run here at all.
+ */
+@Bootstrapped
+@DisplayName("PaletteDefinition")
+class PaletteDefinitionTest {
+
+	@Test
+	@DisplayName("the default palette is a single shared instance")
+	void defaultPaletteIsShared() {
+		assertSame(PaletteDefinition.defaultPalette(), PaletteDefinition.defaultPalette());
+	}
+
+	@Test
+	@DisplayName("cloning yields a separate palette")
+	void cloneIsSeparate() {
+		PaletteDefinition shared = PaletteDefinition.defaultPalette();
+		PaletteDefinition clone = shared.clone();
+
+		assertNotSame(shared, clone);
+		assertNotSame(shared.getDefinition(), clone.getDefinition(), "the clone aliased the same map");
+	}
+
+	@Test
+	@DisplayName("editing a clone leaves the shared default alone")
+	void editingACloneLeavesTheDefaultAlone() {
+		PaletteDefinition shared = PaletteDefinition.defaultPalette();
+		BlockState before = shared.get(Palette.ROOF_PRIMARY);
+
+		PaletteDefinition clone = shared.clone();
+		clone.put(Palette.ROOF_PRIMARY, Blocks.GOLD_BLOCK);
+
+		assertEquals(before, shared.get(Palette.ROOF_PRIMARY),
+			"editing a cloned palette rewrote the shared default");
+		assertEquals(Blocks.GOLD_BLOCK.defaultBlockState(), clone.get(Palette.ROOF_PRIMARY),
+			"the edit did not reach the clone");
+	}
+
+	@Test
+	@DisplayName("two clones of the default do not alias each other")
+	void clonesDoNotAliasEachOther() {
+		PaletteDefinition primary = PaletteDefinition.defaultPalette()
+			.clone();
+		PaletteDefinition secondary = PaletteDefinition.defaultPalette()
+			.clone();
+
+		primary.put(Palette.FLOOR, Blocks.GOLD_BLOCK);
+
+		assertNotSame(primary, secondary);
+		assertEquals(PaletteDefinition.defaultPalette()
+			.get(Palette.FLOOR), secondary.get(Palette.FLOOR),
+			"editing one clone reached another");
+	}
+
+	@Test
+	@DisplayName("a clone inherits every entry it does not override")
+	void cloneInheritsEveryEntry() {
+		PaletteDefinition clone = PaletteDefinition.defaultPalette()
+			.clone();
+
+		for (Palette key : Palette.values())
+			assertEquals(PaletteDefinition.defaultPalette()
+				.get(key), clone.get(key), "clone lost the entry for " + key);
+	}
+
+	@Test
+	@DisplayName("an unset key falls back to air rather than null")
+	void unsetKeyFallsBackToAir() {
+		PaletteDefinition empty = new PaletteDefinition("empty");
+
+		assertEquals(Blocks.AIR.defaultBlockState(), empty.get(Palette.ROOF_PRIMARY));
+	}
+
+	@Test
+	@DisplayName("CLEAR is always the barrier, whatever the source said")
+	void clearIsAlwaysBarrier() {
+		PaletteDefinition clone = PaletteDefinition.defaultPalette()
+			.clone();
+		clone.put(Palette.CLEAR, Blocks.GOLD_BLOCK);
+
+		assertEquals(Blocks.BARRIER.defaultBlockState(), clone.clone()
+			.get(Palette.CLEAR), "a cloned palette kept a non-barrier CLEAR");
+		assertEquals(Blocks.BARRIER.defaultBlockState(),
+			PaletteDefinition.fromNBT(clone.writeToNBT(new CompoundTag()))
+				.get(Palette.CLEAR),
+			"a deserialized palette kept a non-barrier CLEAR");
+	}
+
+	@Test
+	@DisplayName("survives an NBT round trip with its name and every entry")
+	void survivesAnNbtRoundTrip() {
+		PaletteDefinition palette = PaletteDefinition.defaultPalette()
+			.clone();
+		palette.setName("Unit Test Palette");
+		palette.put(Palette.ROOF_PRIMARY, Blocks.GOLD_BLOCK);
+
+		PaletteDefinition roundTrip = PaletteDefinition.fromNBT(palette.writeToNBT(new CompoundTag()));
+
+		assertEquals("Unit Test Palette", roundTrip.getName());
+		for (Palette key : Palette.values())
+			assertEquals(palette.get(key), roundTrip.get(key), "the round trip lost the entry for " + key);
+	}
+
+	/**
+	 * Palette loading used to require being in a world, which is why it had to be deferred until
+	 * joining one. Nothing here has a world, so this passing at all is the assertion.
+	 */
+	@Test
+	@DisplayName("loads with no world, and tolerates missing or empty NBT")
+	void loadsWithNoWorld() {
+		assertNotNull(PaletteDefinition.fromNBT(null), "a null tag should still give a usable palette");
+		assertNotNull(PaletteDefinition.fromNBT(new CompoundTag()),
+			"an empty tag should still give a usable palette");
+		assertEquals(PaletteDefinition.defaultPalette()
+			.get(Palette.ROOF_PRIMARY),
+			PaletteDefinition.fromNBT(null)
+				.get(Palette.ROOF_PRIMARY),
+			"a palette read from nothing should fall back to the default entries");
+	}
+
+	@Test
+	@DisplayName("scan finds the key a blockstate is bound to")
+	void scanFindsTheKey() {
+		PaletteDefinition palette = PaletteDefinition.defaultPalette()
+			.clone();
+		palette.put(Palette.ROOF_PRIMARY, Blocks.GOLD_BLOCK);
+
+		assertSame(Palette.ROOF_PRIMARY, palette.scan(Blocks.GOLD_BLOCK.defaultBlockState()));
+		assertNull(palette.scan(Blocks.AIR.defaultBlockState()), "air is not a palette entry");
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/SchematicBoundsTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/SchematicBoundsTest.java
@@ -1,0 +1,125 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.Schematic;
+import com.timmie.mightyarchitect.control.compose.Cuboid;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.core.BlockPos;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The bounding box a materialized sketch reports is accumulated one block at a time as the palette
+ * is applied, and everything downstream sizes itself from it - the structure template written to
+ * disk, the renderer's chunk, the outline drawn in the world. An off-by-one here crops the printed
+ * building rather than throwing.
+ * <p>
+ * This is the whole of {@code materializeSketch} that can run outside a game: the rest of it ends
+ * in a {@code TemplateBlockAccess}, which reads the client's level.
+ */
+@Bootstrapped
+@DisplayName("Schematic.growToInclude")
+class SchematicBoundsTest {
+
+	private static Cuboid boundsOf(BlockPos... positions) {
+		Cuboid bounds = null;
+		for (BlockPos pos : positions)
+			bounds = Schematic.growToInclude(bounds, pos);
+		return bounds;
+	}
+
+	@Test
+	@DisplayName("the first position gives a one-block box at that position")
+	void firstPositionGivesAUnitBox() {
+		Cuboid bounds = boundsOf(new BlockPos(3, 4, 5));
+
+		assertEquals(new BlockPos(3, 4, 5), bounds.getOrigin());
+		assertEquals(new BlockPos(1, 1, 1), bounds.getSize());
+	}
+
+	@Test
+	@DisplayName("repeating a position does not grow the box")
+	void repeatingAPositionIsIdempotent() {
+		BlockPos pos = new BlockPos(3, 4, 5);
+
+		assertEquals(new BlockPos(1, 1, 1), boundsOf(pos, pos, pos)
+			.getSize());
+	}
+
+	@Test
+	@DisplayName("grows forwards to include a position past the far corner")
+	void growsForwards() {
+		Cuboid bounds = boundsOf(BlockPos.ZERO, new BlockPos(2, 3, 4));
+
+		assertEquals(BlockPos.ZERO, bounds.getOrigin());
+		assertEquals(new BlockPos(3, 4, 5), bounds.getSize());
+	}
+
+	@Test
+	@DisplayName("grows backwards by moving the origin")
+	void growsBackwards() {
+		Cuboid bounds = boundsOf(BlockPos.ZERO, new BlockPos(-2, -3, -4));
+
+		assertEquals(new BlockPos(-2, -3, -4), bounds.getOrigin());
+		assertEquals(new BlockPos(3, 4, 5), bounds.getSize());
+	}
+
+	@Test
+	@DisplayName("grows in both directions on the same axis")
+	void growsBothWays() {
+		Cuboid bounds = boundsOf(BlockPos.ZERO, new BlockPos(5, 0, 0), new BlockPos(-5, 0, 0));
+
+		assertEquals(-5, bounds.getOrigin()
+			.getX());
+		assertEquals(11, bounds.getSize()
+			.getX());
+	}
+
+	/**
+	 * The property, rather than a hand-computed number: whatever order the positions arrive in -
+	 * and they arrive in {@code HashMap} order, so it really is arbitrary - the box has to contain
+	 * every one of them and be no larger than it has to be.
+	 */
+	@Test
+	@DisplayName("contains every position it was grown over, however they were ordered")
+	void containsEveryPositionInAnyOrder() {
+		List<BlockPos> positions = List.of(new BlockPos(4, 1, -7), new BlockPos(-3, 9, 2), new BlockPos(0, 0, 0),
+			new BlockPos(12, -4, 5), new BlockPos(-8, 2, 11));
+
+		Cuboid forwards = boundsOf(positions.toArray(BlockPos[]::new));
+		List<BlockPos> reversed = new java.util.ArrayList<>(positions);
+		java.util.Collections.reverse(reversed);
+		Cuboid backwards = boundsOf(reversed.toArray(BlockPos[]::new));
+
+		assertEquals(forwards.getOrigin(), backwards.getOrigin(), "the box depended on insertion order");
+		assertEquals(forwards.getSize(), backwards.getSize(), "the box depended on insertion order");
+
+		for (BlockPos pos : positions)
+			assertTrue(forwards.contains(pos), () -> "the box excluded " + pos);
+
+		assertEquals(new BlockPos(-8, -4, -7), forwards.getOrigin());
+		assertEquals(new BlockPos(21, 14, 19), forwards.getSize());
+	}
+
+	@Test
+	@DisplayName("a single-plane sketch still has one block of depth")
+	void flatSketchIsOneDeep() {
+		Cuboid bounds = boundsOf(new BlockPos(0, 0, 0), new BlockPos(3, 0, 3));
+
+		assertEquals(1, bounds.getSize()
+			.getY(), "a flat sketch collapsed to zero height");
+	}
+
+	@Test
+	@DisplayName("grows the box in place rather than replacing it")
+	void growsInPlace() {
+		Cuboid bounds = Schematic.growToInclude(null, BlockPos.ZERO);
+
+		assertSame(bounds, Schematic.growToInclude(bounds, new BlockPos(9, 9, 9)));
+	}
+}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/SketchAssembleTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/SketchAssembleTest.java
@@ -1,0 +1,226 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.compose.Room;
+import com.timmie.mightyarchitect.control.design.DesignLayer;
+import com.timmie.mightyarchitect.control.design.Sketch;
+import com.timmie.mightyarchitect.control.design.partials.Design;
+import com.timmie.mightyarchitect.control.palette.BlockOrientation;
+import com.timmie.mightyarchitect.control.palette.Palette;
+import com.timmie.mightyarchitect.control.palette.PaletteBlockInfo;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Vector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code Sketch.assemble} flattens the placed designs into the two palette layers the printer
+ * consumes, then cleans and floors them. It is the last step before anything becomes blocks, and
+ * it is pure map arithmetic over {@link BlockPos} - no world, no rendering.
+ * <p>
+ * The two rules it enforces are easy to get silently wrong: {@code CLEAR} marks a hole that must
+ * be punched through <em>both</em> layers, and a room's interior must be emptied unless its layer
+ * is an exterior one. Both are "something is missing" bugs, which is the kind a screenshot test
+ * cannot see.
+ */
+@Bootstrapped
+@DisplayName("Sketch.assemble")
+class SketchAssembleTest {
+
+	private static final int PRIMARY = 0;
+	private static final int SECONDARY = 1;
+
+	/**
+	 * A design that contributes exactly the blocks it was handed. The real subclasses read their
+	 * geometry out of NBT slices; none of that is what {@code assemble} does with the result.
+	 */
+	private static Design fixedDesign(Map<BlockPos, PaletteBlockInfo> fixed) {
+		return new Design() {
+			@Override
+			public Design fromNBT(CompoundTag compound) {
+				return this;
+			}
+
+			@Override
+			public void getBlocks(DesignInstance instance, Map<BlockPos, PaletteBlockInfo> blocks) {
+				blocks.putAll(fixed);
+			}
+		};
+	}
+
+	private static Design.DesignInstance instanceOf(Map<BlockPos, PaletteBlockInfo> fixed) {
+		return fixedDesign(fixed).create(BlockPos.ZERO, 0, 1, 1);
+	}
+
+	private static Map<BlockPos, PaletteBlockInfo> blocks(Object... posThenPalette) {
+		Map<BlockPos, PaletteBlockInfo> map = new HashMap<>();
+		for (int i = 0; i < posThenPalette.length; i += 2)
+			map.put((BlockPos) posThenPalette[i],
+				new PaletteBlockInfo((Palette) posThenPalette[i + 1], BlockOrientation.NONE));
+		return map;
+	}
+
+	@Test
+	@DisplayName("returns the primary layer first and the secondary second")
+	void returnsBothLayersInOrder() {
+		Sketch sketch = new Sketch();
+		sketch.primary.add(instanceOf(blocks(new BlockPos(1, 0, 0), Palette.INNER_PRIMARY)));
+		sketch.secondary.add(instanceOf(blocks(new BlockPos(2, 0, 0), Palette.ROOF_PRIMARY)));
+
+		Vector<Map<BlockPos, PaletteBlockInfo>> assembled = sketch.assemble();
+
+		assertEquals(2, assembled.size());
+		assertSame(Palette.INNER_PRIMARY, assembled.get(PRIMARY)
+			.get(new BlockPos(1, 0, 0)).palette);
+		assertSame(Palette.ROOF_PRIMARY, assembled.get(SECONDARY)
+			.get(new BlockPos(2, 0, 0)).palette);
+		assertFalse(assembled.get(PRIMARY)
+			.containsKey(new BlockPos(2, 0, 0)), "the secondary layer leaked into the primary");
+	}
+
+	@Test
+	@DisplayName("an empty sketch assembles to two empty layers, not to null")
+	void emptySketchAssembles() {
+		Vector<Map<BlockPos, PaletteBlockInfo>> assembled = new Sketch().assemble();
+
+		assertEquals(2, assembled.size());
+		assertTrue(assembled.get(PRIMARY)
+			.isEmpty());
+		assertTrue(assembled.get(SECONDARY)
+			.isEmpty());
+	}
+
+	@Test
+	@DisplayName("CLEAR punches a hole through both layers")
+	void clearRemovesFromBothLayers() {
+		BlockPos shared = new BlockPos(1, 0, 0);
+
+		Sketch sketch = new Sketch();
+		sketch.primary.add(instanceOf(blocks(shared, Palette.CLEAR)));
+		sketch.secondary.add(instanceOf(blocks(shared, Palette.ROOF_PRIMARY)));
+
+		Vector<Map<BlockPos, PaletteBlockInfo>> assembled = sketch.assemble();
+
+		assertFalse(assembled.get(PRIMARY)
+			.containsKey(shared), "CLEAR did not remove its own layer");
+		assertFalse(assembled.get(SECONDARY)
+			.containsKey(shared), "CLEAR did not punch through the other layer");
+	}
+
+	@Test
+	@DisplayName("a room's interior is emptied out of both layers")
+	void interiorIsCleared() {
+		BlockPos inside = new BlockPos(2, 1, 2);
+		BlockPos outside = new BlockPos(9, 1, 9);
+
+		Sketch sketch = new Sketch();
+		sketch.primary.add(instanceOf(blocks(inside, Palette.INNER_PRIMARY, outside, Palette.INNER_PRIMARY)));
+		sketch.interior.add(room(new BlockPos(0, 0, 0), 6, 4, 6, DesignLayer.Regular));
+
+		Vector<Map<BlockPos, PaletteBlockInfo>> assembled = sketch.assemble();
+
+		assertFalse(assembled.get(PRIMARY)
+			.containsKey(inside), "a block inside the room survived cleaning");
+		assertTrue(assembled.get(PRIMARY)
+			.containsKey(outside), "a block outside the room was cleaned away");
+	}
+
+	/** Exterior layers are the outside of the building, so their volume must not be hollowed. */
+	@Test
+	@DisplayName("an exterior room's interior is left alone")
+	void exteriorRoomIsNotCleared() {
+		BlockPos inside = new BlockPos(2, 1, 2);
+
+		Sketch sketch = new Sketch();
+		sketch.primary.add(instanceOf(blocks(inside, Palette.INNER_PRIMARY)));
+		sketch.interior.add(room(new BlockPos(0, 0, 0), 6, 4, 6, DesignLayer.Open));
+
+		assertTrue(sketch.assemble()
+			.get(PRIMARY)
+			.containsKey(inside), "an exterior room hollowed itself out");
+	}
+
+	@Test
+	@DisplayName("every room gets a floor at its top layer")
+	void roomsGetAFloor() {
+		Sketch sketch = new Sketch();
+		sketch.interior.add(room(new BlockPos(0, 0, 0), 3, 4, 2, DesignLayer.Regular));
+
+		Map<BlockPos, PaletteBlockInfo> primary = sketch.assemble()
+			.get(PRIMARY);
+
+		assertEquals(3 * 2, primary.size(), "the floor did not cover the room's footprint exactly");
+		for (int x = 0; x < 3; x++)
+			for (int z = 0; z < 2; z++) {
+				BlockPos pos = new BlockPos(x, 3, z);
+				assertTrue(primary.containsKey(pos), () -> "no floor at " + pos);
+				assertSame(Palette.FLOOR, primary.get(pos).palette);
+				assertSame(BlockOrientation.TOP_UP, primary.get(pos).afterPosition,
+					"the floor was not laid on top of its layer");
+			}
+	}
+
+	@Test
+	@DisplayName("a room on the secondary palette floors the secondary layer")
+	void secondaryPaletteRoomFloorsTheSecondaryLayer() {
+		Room room = room(new BlockPos(0, 0, 0), 2, 2, 2, DesignLayer.Regular);
+		room.secondaryPalette = true;
+
+		Sketch sketch = new Sketch();
+		sketch.interior.add(room);
+
+		Vector<Map<BlockPos, PaletteBlockInfo>> assembled = sketch.assemble();
+
+		assertTrue(assembled.get(PRIMARY)
+			.isEmpty(), "a secondary-palette room floored the primary layer");
+		assertEquals(4, assembled.get(SECONDARY)
+			.size());
+	}
+
+	/** A room with a one-tall room sitting directly on it is a floor for that room, not a ceiling. */
+	@Test
+	@DisplayName("a covering trim room suppresses the floor below it")
+	void trimAboveSuppressesTheFloor() {
+		Sketch sketch = new Sketch();
+		sketch.interior.add(room(new BlockPos(0, 0, 0), 4, 3, 4, DesignLayer.Regular));
+		sketch.interior.add(room(new BlockPos(0, 3, 0), 4, 1, 4, DesignLayer.Regular));
+
+		Map<BlockPos, PaletteBlockInfo> primary = sketch.assemble()
+			.get(PRIMARY);
+
+		assertEquals(4 * 4, primary.size(),
+			"the covered room floored itself as well as the trim above it");
+		assertTrue(primary.containsKey(new BlockPos(0, 3, 0)));
+	}
+
+	@Test
+	@DisplayName("a smaller overlapping room takes precedence over the floor above it")
+	void overlappingSmallerRoomKeepsItsSpace() {
+		Sketch sketch = new Sketch();
+		sketch.interior.add(room(new BlockPos(0, 0, 0), 4, 2, 4, DesignLayer.Regular));
+		// Occupies the same y as the big room's floor layer, and is smaller, so it wins there.
+		sketch.interior.add(room(new BlockPos(0, 0, 0), 2, 2, 2, DesignLayer.Regular));
+
+		Map<BlockPos, PaletteBlockInfo> primary = sketch.assemble()
+			.get(PRIMARY);
+
+		assertFalse(primary.isEmpty(), "no floor was laid at all");
+		assertTrue(primary.containsKey(new BlockPos(3, 1, 3)),
+			"the larger room lost the part of its floor nothing overlapped");
+	}
+
+	private static Room room(BlockPos origin, int width, int height, int length, DesignLayer layer) {
+		Room room = new Room(origin, width, height, length);
+		room.designLayer = layer;
+		return room;
+	}
+}


### PR DESCRIPTION
## What

Adds `unit-test/`, a JUnit suite for the mod's pure, version-agnostic logic, run through [`fabric-loader-junit`](https://maven.fabricmc.net/net/fabricmc/fabric-loader-junit/) on the Fabric branch.

**117 assertions, 0.4 s of actual execution** after a one-off `Bootstrap.bootStrap()`. A single node's suite is ~20 s warm, against a ~16-minute CI cycle.

This is PR 1 of the audit's six-PR execution plan and absorbs **P3.9**. It is deliberately first despite being item 9 by priority: it is guard-free, its file set is disjoint from every other batch, and it is what makes PRs 2–5 verifiable in seconds. PR 2 in particular is codec round-trips and path derivation — exactly the pure logic a JUnit suite settles fastest.

## Why now

The mod had **no unit tests at all**. #38 made that vivid: it added nine assertions to the *client-test companion* — filename derivation and idempotence, `slug` traversal safety, palette independence, lenient enum parsing, the `hashCode`/`equals` contract — because there was nowhere else to put them. Every one paid a full game boot on 25 targets to check arithmetic. They existed; they were simply in the wrong place. They move here.

## Shape

- New top-level module `unit-test/`, mirroring `client-test/` and `server-test/`. Like them it is **not Stonecutter-processed**, so everything in it has to compile unchanged from 1.19.4 to 26.2 — which is what makes running it on all 13 nodes meaningful rather than redundant.
- Wired as the `test` source set in `fabric/build.gradle`. `test` is already part of `check` → `build`, so **CI runs it per node with no workflow change** — `.github/workflows/build.yml` is untouched, which also keeps this PR's file set disjoint from #39's.
- `unitTestAll` added next to `compileAll` in `stonecutter.gradle`.
- The test JVM's working directory is moved under `build/`. Booting the registries starts log4j's file appender, and the mod's own storage paths are relative, so on the default working directory the suite would litter the source tree.

### Two decisions worth flagging

**`SharedConstants.tryDetectVersion()` + `Bootstrap.bootStrap()` needs no guard.** javap'd against all 13 Mojang-mapped jars in the Loom cache: both are byte-identical on every node, 1.19.4 through 26.2. That is the only reason a version-agnostic harness is possible at all.

**`junit-jupiter-params` is deliberately not declared.** `fabric-loader-junit` brings `junit-jupiter-engine` and `junit-platform-launcher` and nothing else, and its JUnit BOM version moves with the loader version — which differs per node (0.16.9 … 0.19.3). Pinning a params version that tracked that would be a maintenance trap for a syntactic convenience. The tables use `@TestFactory` + `DynamicTest` from `junit-jupiter-api` instead, which gives the same per-case reporting.

## Coverage

| class | what it pins |
| --- | --- |
| `FilesHelperSlugTest` | traversal safety over a table of 10 hostile names, stated as a property (resolves inside its folder, exactly one path element), plus reserved device names, the 64-char cap and `slugOr`'s fallback |
| `DesignExporterFilenameTest` | derivation, **idempotence** (what makes re-export overwrite instead of orphaning), blank fallback, traversal |
| `CuboidTest` | negative/mixed-sign normalization, the `equals`/`hashCode` contract *as a `HashMap` key*, half-open `contains`, height-ignoring `intersects`, all six `moveToAttach` directions, `Room` interior/stack/orientation |
| `PaletteDefinitionTest` | the shared-default aliasing bug from three angles, `CLEAR` always being the barrier, NBT round-trip, and loading **with no world** |
| `DesignThemeTest` | lenient enum parsing — one unknown name costs one entry, not the whole list — plus `createTheme`'s palettes and sanitized folder name |
| `SchematicBoundsTest` | bounds accumulation, including order-independence |
| `SketchAssembleTest` | layer split, `CLEAR` punching through **both** layers, interior clearing (and *not* clearing exterior layers), floor insertion and trim suppression |
| `InstantPrintPacketChunkingTest` | exact packet counts, that no packet ever exceeds the bound **the decoder enforces**, no loss/duplication, anchor applied once |

## Test seams added to production code

Three, all narrow and documented, in the shape #35 already established when it made `ServerBuildGuard.withinReach` and `MAX_BUILD_DISTANCE` public for the server-test companion:

1. **`ThemeStorage.createTheme(name, designer)`** — the one-arg overload still reads the local player. The designer is data; the client dependency was the only thing keeping the name fallback, the file-path slug and the palette cloning out of reach.
2. **`Schematic.growToInclude(Cuboid, BlockPos)`** — the old private `checkBounds`, with the bounds passed in and returned rather than read off the field. The rest of `materializeSketch` ends in a `TemplateBlockAccess`, which reads `Minecraft.getInstance().level`, so this is the only part of it that can run outside a game.
3. **`InstantPrintPacket.MAX_BLOCKS_PER_PACKET`** (promoted from `BunchOfBlocks.MAX_SIZE`, same value, all five use sites migrated) plus `blocks()` and `size()`.

## Gate — mutation tested

Per the project rule that a gate never seen to fail is not yet a gate:

| mutation | result |
| --- | --- |
| let `/` and `.` through `FilesHelper.slug` | **18 of 117** red, across `FilesHelper.slug`, `DesignExporter.designFilename` and `ThemeStorage.createTheme` |
| delete `this.quadFacadeRoof = false` from `Room.stack` | **1** red |

The second one exists because review caught that assertion being **vacuous** as first written — the fixture was a 6×8 room, whose `quadFacadeRoof` is already `false` at construction, so it would have passed with the production line deleted. It now uses a square footprint and has been seen to fail.

## Verification

- Suite green on **1.19.4, 1.20.2, 1.21.1, 1.21.6, 1.21.11, 26.1, 26.2** locally — 117/117 on each. That covers JDK 17/21/25, obfuscated and unobfuscated, all three networking eras, the 1.21.6 NBT `Optional` boundary and the 1.21.11 `Identifier` rename. CI covers the remaining six.
- `:fabric:1.21.1:build` green — the client-test companion still compiles after the removal.
- `common/` changed, so cross-loader compile checked too: `:neoforge:1.21.1:` and `:forge:1.19.4:` `compileJava` + `compileClientTestJava` + `compileServerTestJava`, all green.

## Effect on the existing matrices

The client matrix goes from **49 to 40 checks** per target, on both the dev and production lanes. Nothing else changes; the one data-integrity assertion that is *not* pure logic — the palette NBT round-trip, which goes through the block registry — stays in the companion.

---

📚 Knowledge base updated: `themightyarchitectury/code-audit` (P3.9 closed) and `themightyarchitectury/development-workflow` (local gates, matrix check counts).
