### PR TITLE
Improve multiplayer print networking

### DIFF
--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -34,6 +34,8 @@ import com.timmie.mightyarchitect.gui.widgets.Indicator;
 import com.timmie.mightyarchitect.gui.widgets.Label;
 import com.timmie.mightyarchitect.gui.widgets.ScrollInput;
 import com.timmie.mightyarchitect.networking.InstantPrintPacket;
+import com.timmie.mightyarchitect.platform.MightyPacket;
+import com.timmie.mightyarchitect.platform.PacketSender;
 import com.timmie.mightyarchitect.test.mixin.ArchitectManagerAccessor;
 import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
@@ -337,7 +339,8 @@ public final class ClientTestController {
             "architect_wand identity recognized");
         InstantPrintPacket printProbe = InstantPrintPacket.sendSchematic(
             Map.of(BlockPos.ZERO, Blocks.STONE.defaultBlockState()), BlockPos.ZERO).get(0);
-        check(AllPackets.canSendToServer(printProbe), "server advertises the instant-print payload");
+        check(!AllPackets.canSendToServer(printProbe),
+            "vanilla server does not advertise the instant-print payload");
         check(!PaletteStorage.getResourcePaletteNames().isEmpty(), "resource palettes loaded");
         check(!ThemeStorage.getIncluded().isEmpty(), "included themes loaded");
 
@@ -357,16 +360,43 @@ public final class ClientTestController {
     }
 
     /**
-     * The harness is connected to a dedicated server, so the old singleplayer predicate would send
-     * this down the command fallback. An empty sketch exercises routing without changing the world.
+     * Exercises both transport decisions without changing the world: the harness's real vanilla
+     * server must retain the command fallback, while an injected available sender stands in for a
+     * modded multiplayer server.
      */
     private static void checkModdedServerPrintRoute() {
         ArchitectManager.compose(ThemeStorage.getIncluded().get(0));
         ArchitectManager.getModel().setSketch(new Sketch());
         ArchitectManager.print();
+        check(ArchitectManager.inPhase(ArchitectPhases.PrintingToMultiplayer),
+            "vanilla multiplayer printing selected the command fallback");
+        ArchitectManager.unload();
 
-        check(ArchitectManager.inPhase(ArchitectPhases.Empty),
-            "modded multiplayer printing selected the payload transport");
+        int[] sent = { 0 };
+        PacketSender actual = AllPackets.setSender(new PacketSender() {
+            @Override
+            public boolean canSendToServer(MightyPacket packet) {
+                return true;
+            }
+
+            @Override
+            public void sendToServer(MightyPacket packet) {
+                sent[0]++;
+            }
+        });
+        try {
+            ArchitectManager.compose(ThemeStorage.getIncluded().get(0));
+            ArchitectManager.getModel().setSketch(new Sketch());
+            ArchitectManager.print();
+
+            check(ArchitectManager.inPhase(ArchitectPhases.Empty),
+                "modded multiplayer printing selected the payload transport");
+            check(sent[0] == 1, "payload transport sent the print packet");
+        } finally {
+            AllPackets.setSender(actual);
+            if (!ArchitectManager.inPhase(ArchitectPhases.Empty))
+                ArchitectManager.unload();
+        }
     }
 
     /**

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -48,6 +48,7 @@ import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
@@ -365,13 +366,6 @@ public final class ClientTestController {
      * modded multiplayer server.
      */
     private static void checkModdedServerPrintRoute() {
-        ArchitectManager.compose(ThemeStorage.getIncluded().get(0));
-        ArchitectManager.getModel().setSketch(new Sketch());
-        ArchitectManager.print();
-        check(ArchitectManager.inPhase(ArchitectPhases.PrintingToMultiplayer),
-            "vanilla multiplayer printing selected the command fallback");
-        ArchitectManager.unload();
-
         int[] sent = { 0 };
         PacketSender actual = AllPackets.setSender(new PacketSender() {
             @Override
@@ -384,15 +378,19 @@ public final class ClientTestController {
                 sent[0]++;
             }
         });
+        GameType previousMode = Minecraft.getInstance().gameMode.getPlayerMode();
         try {
+            Minecraft.getInstance().gameMode.setLocalMode(GameType.CREATIVE);
             ArchitectManager.compose(ThemeStorage.getIncluded().get(0));
             ArchitectManager.getModel().setSketch(new Sketch());
+            ArchitectManager.enterPhase(ArchitectPhases.Previewing);
             ArchitectManager.print();
 
             check(ArchitectManager.inPhase(ArchitectPhases.Empty),
                 "modded multiplayer printing selected the payload transport");
             check(sent[0] == 1, "payload transport sent the print packet");
         } finally {
+            Minecraft.getInstance().gameMode.setLocalMode(previousMode);
             AllPackets.setSender(actual);
             if (!ArchitectManager.inPhase(ArchitectPhases.Empty))
                 ArchitectManager.unload();

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestController.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.timmie.mightyarchitect.AllBlocks;
 import com.timmie.mightyarchitect.AllItems;
+import com.timmie.mightyarchitect.AllPackets;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.TheMightyArchitect;
 import com.timmie.mightyarchitect.control.ArchitectManager;
@@ -32,6 +33,7 @@ import com.timmie.mightyarchitect.gui.TextInputPromptScreen;
 import com.timmie.mightyarchitect.gui.widgets.Indicator;
 import com.timmie.mightyarchitect.gui.widgets.Label;
 import com.timmie.mightyarchitect.gui.widgets.ScrollInput;
+import com.timmie.mightyarchitect.networking.InstantPrintPacket;
 import com.timmie.mightyarchitect.test.mixin.ArchitectManagerAccessor;
 import com.mojang.blaze3d.platform.Window;
 import net.minecraft.client.Minecraft;
@@ -333,9 +335,13 @@ public final class ClientTestController {
             "slice_marker registered");
         check(AllItems.ARCHITECT_WAND.typeOf(new ItemStack(AllItems.ARCHITECT_WAND.get())),
             "architect_wand identity recognized");
+        InstantPrintPacket printProbe = InstantPrintPacket.sendSchematic(
+            Map.of(BlockPos.ZERO, Blocks.STONE.defaultBlockState()), BlockPos.ZERO).get(0);
+        check(AllPackets.canSendToServer(printProbe), "server advertises the instant-print payload");
         check(!PaletteStorage.getResourcePaletteNames().isEmpty(), "resource palettes loaded");
         check(!ThemeStorage.getIncluded().isEmpty(), "included themes loaded");
 
+        checkModdedServerPrintRoute();
         checkPaletteRoundTrip();
 
         // WrappedWorld overrides methods NeoForge adds to Level that vanilla does not have. Those
@@ -348,6 +354,19 @@ public final class ClientTestController {
             "WrappedWorld loads and delegates to the wrapped level");
 
         advance(Stage.CAPTURE_BASELINE);
+    }
+
+    /**
+     * The harness is connected to a dedicated server, so the old singleplayer predicate would send
+     * this down the command fallback. An empty sketch exercises routing without changing the world.
+     */
+    private static void checkModdedServerPrintRoute() {
+        ArchitectManager.compose(ThemeStorage.getIncluded().get(0));
+        ArchitectManager.getModel().setSketch(new Sketch());
+        ArchitectManager.print();
+
+        check(ArchitectManager.inPhase(ArchitectPhases.Empty),
+            "modded multiplayer printing selected the payload transport");
     }
 
     /**

--- a/common/src/main/java/com/timmie/mightyarchitect/AllPackets.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/AllPackets.java
@@ -46,11 +46,23 @@ public class AllPackets {
 	public static final Function<FriendlyByteBuf, SetHotbarItemPacket> SET_HOTBAR_ITEM_DECODER = SetHotbarItemPacket::new;
 	*///?}
 
-	private static PacketSender sender = packet -> {
+	private static PacketSender sender = new PacketSender() {
+		@Override
+		public boolean canSendToServer(MightyPacket packet) {
+			return false;
+		}
+
+		@Override
+		public void sendToServer(MightyPacket packet) {
+		}
 	};
 
 	public static void setSender(PacketSender value) {
 		sender = value;
+	}
+
+	public static boolean canSendToServer(MightyPacket packet) {
+		return sender.canSendToServer(packet);
 	}
 
 	public static void sendToServer(MightyPacket packet) {

--- a/common/src/main/java/com/timmie/mightyarchitect/AllPackets.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/AllPackets.java
@@ -57,8 +57,10 @@ public class AllPackets {
 		}
 	};
 
-	public static void setSender(PacketSender value) {
-		sender = value;
+	public static PacketSender setSender(PacketSender value) {
+		PacketSender previous = sender;
+		sender = java.util.Objects.requireNonNull(value, "value");
+		return previous;
 	}
 
 	public static boolean canSendToServer(MightyPacket packet) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
@@ -129,6 +129,11 @@ public class ArchitectManager {
 		List<InstantPrintPacket> packets = getModel().getPackets();
 
 		if (!packets.isEmpty() && AllPackets.canSendToServer(packets.get(0))) {
+			if (!Minecraft.getInstance().gameMode.getPlayerMode().isCreative()
+				&& !hasGameMasterPermission()) {
+				reportPrintPermissionDenied();
+				return;
+			}
 			for (InstantPrintPacket packet : packets)
 				AllPackets.sendToServer(packet);
 			MightyClient.renderer.setActive(false);
@@ -137,7 +142,31 @@ public class ArchitectManager {
 			return;
 		}
 
+		if (!hasGameMasterPermission()) {
+			reportPrintPermissionDenied();
+			return;
+		}
 		enterPhase(ArchitectPhases.PrintingToMultiplayer);
+	}
+
+	private static boolean hasGameMasterPermission() {
+		// Numeric permission levels were replaced by named permissions in 1.21.11.
+		//? if >=1.21.11 {
+		return Minecraft.getInstance().player.permissions()
+			.hasPermission(net.minecraft.server.permissions.Permissions.COMMANDS_GAMEMASTER);
+		//?} else {
+		/*return Minecraft.getInstance().player.hasPermissions(2);
+		*///?}
+	}
+
+	private static void reportPrintPermissionDenied() {
+		Component message = Component.literal(
+			ChatFormatting.RED + "You do not have permission to print on this server.");
+		//? if >=26 {
+		Minecraft.getInstance().player.sendSystemMessage(message);
+		//?} else {
+		/*Minecraft.getInstance().player.displayClientMessage(message, false);
+		*///?}
 	}
 
 	public static void writeToFile(String name) {

--- a/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/ArchitectManager.java
@@ -39,6 +39,7 @@ import net.minecraft.network.chat.Component;
 import org.lwjgl.glfw.GLFW;
 
 import java.nio.file.Path;
+import java.util.List;
 
 public class ArchitectManager {
 
@@ -125,10 +126,10 @@ public class ArchitectManager {
 		if (getModel().getSketch() == null)
 			return;
 
-		Minecraft mc = Minecraft.getInstance();
+		List<InstantPrintPacket> packets = getModel().getPackets();
 
-		if (mc.hasSingleplayerServer()) {
-			for (InstantPrintPacket packet : getModel().getPackets())
+		if (!packets.isEmpty() && AllPackets.canSendToServer(packets.get(0))) {
+			for (InstantPrintPacket packet : packets)
 				AllPackets.sendToServer(packet);
 			MightyClient.renderer.setActive(false);
 			status("Printed result into world.");

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/MultiplayerPrintCommands.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/MultiplayerPrintCommands.java
@@ -1,0 +1,143 @@
+package com.timmie.mightyarchitect.control.phase;
+
+import net.minecraft.commands.arguments.blocks.BlockStateParser;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction.Axis;
+import net.minecraft.world.level.block.state.BlockState;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Plans the command fallback used when the connected server does not advertise the mod's payloads.
+ */
+public final class MultiplayerPrintCommands {
+
+	/**
+	 * The vanilla limit defaults to 32,768 but is server-configurable and not synchronized to the
+	 * client. Small fills still cut command volume sharply without making one rejection lose a
+	 * whole wall.
+	 */
+	private static final int MAX_FILL_BLOCKS = 32;
+	private static final List<Axis> AXES = List.of(Axis.X, Axis.Z, Axis.Y);
+	private static final Comparator<BlockPos> POSITION_ORDER = Comparator.comparingInt(
+		(BlockPos pos) -> pos.getY())
+		.thenComparingInt(pos -> pos.getZ())
+		.thenComparingInt(pos -> pos.getX());
+
+	private MultiplayerPrintCommands() {
+	}
+
+	/**
+	 * Greedily collapses contiguous equal-state blocks into one-dimensional fill commands.
+	 * Singletons remain setblock commands.
+	 */
+	public static List<Command> plan(Map<BlockPos, BlockState> blocks) {
+		Map<BlockPos, BlockState> remaining = new HashMap<>(blocks);
+		List<BlockPos> ordered = new ArrayList<>(blocks.keySet());
+		ordered.sort(POSITION_ORDER);
+
+		List<Command> commands = new ArrayList<>();
+		for (BlockPos start : ordered) {
+			if (!remaining.containsKey(start))
+				continue;
+			BlockState state = Objects.requireNonNull(remaining.get(start), "state at " + start);
+
+			Run longest = new Run(Axis.X, 1);
+			for (Axis axis : AXES) {
+				int length = runLength(remaining, start, state, axis);
+				if (length > longest.length())
+					longest = new Run(axis, length);
+			}
+
+			BlockPos end = start;
+			for (int i = 0; i < longest.length(); i++) {
+				remaining.remove(end);
+				if (i + 1 < longest.length())
+					end = advance(end, longest.axis());
+			}
+			commands.add(new Command(start, end, state));
+		}
+		return List.copyOf(commands);
+	}
+
+	/** Replans one queued run after dropping positions that are no longer safe to place. */
+	public static List<Command> replan(Command command, Predicate<BlockPos> include) {
+		Map<BlockPos, BlockState> blocks = new HashMap<>();
+		for (BlockPos pos : command.positions())
+			if (include.test(pos))
+				blocks.put(pos, command.state());
+		return plan(blocks);
+	}
+
+	private static int runLength(Map<BlockPos, BlockState> blocks, BlockPos start, BlockState state,
+		Axis axis) {
+		int length = 1;
+		BlockPos next = advance(start, axis);
+		while (length < MAX_FILL_BLOCKS && state.equals(blocks.get(next))) {
+			length++;
+			next = advance(next, axis);
+		}
+		return length;
+	}
+
+	private static BlockPos advance(BlockPos pos, Axis axis) {
+		return switch (axis) {
+			case X -> pos.offset(1, 0, 0);
+			case Y -> pos.offset(0, 1, 0);
+			case Z -> pos.offset(0, 0, 1);
+		};
+	}
+
+	private record Run(Axis axis, int length) {
+	}
+
+	public record Command(BlockPos from, BlockPos to, BlockState state) {
+
+		public Command {
+			Objects.requireNonNull(from, "from");
+			Objects.requireNonNull(to, "to");
+			Objects.requireNonNull(state, "state");
+			int varyingAxes = (from.getX() == to.getX() ? 0 : 1)
+				+ (from.getY() == to.getY() ? 0 : 1)
+				+ (from.getZ() == to.getZ() ? 0 : 1);
+			if (varyingAxes > 1)
+				throw new IllegalArgumentException("fill run must be one-dimensional");
+		}
+
+		public String text() {
+			String serialized = BlockStateParser.serialize(state);
+			if (from.equals(to))
+				return "setblock " + coordinates(from) + " " + serialized;
+			return "fill " + coordinates(from) + " " + coordinates(to) + " " + serialized;
+		}
+
+		public int blockCount() {
+			return Math.abs(to.getX() - from.getX())
+				+ Math.abs(to.getY() - from.getY())
+				+ Math.abs(to.getZ() - from.getZ()) + 1;
+		}
+
+		public List<BlockPos> positions() {
+			int dx = Integer.compare(to.getX(), from.getX());
+			int dy = Integer.compare(to.getY(), from.getY());
+			int dz = Integer.compare(to.getZ(), from.getZ());
+			List<BlockPos> positions = new ArrayList<>(blockCount());
+			BlockPos pos = from;
+			for (int i = 0; i < blockCount(); i++) {
+				positions.add(pos);
+				pos = pos.offset(dx, dy, dz);
+			}
+			return List.copyOf(positions);
+		}
+
+		private static String coordinates(BlockPos pos) {
+			return pos.getX() + " " + pos.getY() + " " + pos.getZ();
+		}
+	}
+}

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/PrintingToMultiplayer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/PrintingToMultiplayer.java
@@ -11,13 +11,19 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.shapes.CollisionContext;
 
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Deque;
 
 public class PrintingToMultiplayer extends PhaseBase {
 
-	static List<BlockPos> remaining;
-	static boolean success;
+	private static final int COMMANDS_PER_TICK = 1;
+	private static final int POSITION_CHECKS_PER_TICK = 8_192;
+
+	private Deque<MultiplayerPrintCommands.Command> remaining;
+	private boolean success;
 
 	@Override
 	public void whenEntered() {
@@ -40,8 +46,13 @@ public class PrintingToMultiplayer extends PhaseBase {
 		// disabled for good if the print was interrupted by a crash, kick or disconnect. The
 		// resulting command feedback in chat is the honest cost of building with commands.
 
-		remaining = new LinkedList<>(getModel().getMaterializedSketch().getAllPositions());
-		remaining.sort((o1, o2) -> Integer.compare(o1.getY(), o2.getY()));
+		Map<BlockPos, BlockState> blocks = new HashMap<>();
+		for (BlockPos localPos : getModel().getMaterializedSketch().getAllPositions()) {
+			BlockPos worldPos = localPos.offset(getModel().getAnchor());
+			BlockState state = getModel().getMaterializedSketch().getBlockState(worldPos);
+			blocks.put(worldPos, state);
+		}
+		remaining = new ArrayDeque<>(MultiplayerPrintCommands.plan(blocks));
 	}
 
 	@Override
@@ -59,32 +70,38 @@ public class PrintingToMultiplayer extends PhaseBase {
 			return;
 		}
 
-		// print 10 blocks an update until completed
-		for (int i = 0; i < 10; i++) {
-			if (!remaining.isEmpty()) {
-				BlockPos pos = remaining.get(0);
-				remaining.remove(0);
-				pos = pos.offset(getModel().getAnchor());
-				BlockState state = getModel().getMaterializedSketch().getBlockState(pos);
-
-				if (minecraft.level.getBlockState(pos) == state)
-					continue;
-				if (!minecraft.level.isUnobstructed(state, pos, CollisionContext.of(minecraft.player)))
-					continue;
-
-				String blockstring = state.toString().replaceFirst("Block\\{", "").replaceFirst("\\}", "");
-
-				String cmd = "setblock " + pos.getX() + " " + pos.getY() + " " + pos.getZ() + " " + blockstring;
-				//? if >=1.21.6 {
-				Minecraft.getInstance().player.connection.sendCommand(cmd);
-				//?} else {
-				/*Minecraft.getInstance().player.connection.sendUnsignedCommand(cmd);
-				*///?}
-			} else {
+		int sent = 0;
+		int checked = 0;
+		while (sent < COMMANDS_PER_TICK && checked < POSITION_CHECKS_PER_TICK) {
+			MultiplayerPrintCommands.Command queued = remaining.pollFirst();
+			if (queued == null) {
 				ArchitectManager.unload();
 				break;
 			}
+			checked += queued.blockCount();
+
+			List<MultiplayerPrintCommands.Command> current = MultiplayerPrintCommands.replan(queued,
+				pos -> isCurrentlyPlaceable(pos, queued.state()));
+			for (int i = current.size() - 1; i > 0; i--)
+				remaining.addFirst(current.get(i));
+			if (current.isEmpty())
+				continue;
+
+			//? if >=1.21.6 {
+			Minecraft.getInstance().player.connection.sendCommand(current.get(0).text());
+			//?} else {
+			/*Minecraft.getInstance().player.connection.sendUnsignedCommand(current.get(0).text());
+			*///?}
+			sent++;
 		}
+	}
+
+	private boolean isCurrentlyPlaceable(BlockPos pos, BlockState state) {
+		// A matching block is left untouched, including any block-entity data already there.
+		return minecraft.level.isInWorldBounds(pos)
+			&& minecraft.level.isLoaded(pos)
+			&& !minecraft.level.getBlockState(pos).equals(state)
+			&& minecraft.level.isUnobstructed(state, pos, CollisionContext.of(minecraft.player));
 	}
 
 	@Override
@@ -106,7 +123,7 @@ public class PrintingToMultiplayer extends PhaseBase {
 	@Override
 	public List<String> getToolTip() {
 		return ImmutableList.of("Please be patient while your building is being transferred.",
-			"Your server will report each block as it is placed.");
+			"Your server will report each command batch as it is placed.");
 	}
 
 }

--- a/common/src/main/java/com/timmie/mightyarchitect/control/phase/PrintingToMultiplayer.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/control/phase/PrintingToMultiplayer.java
@@ -23,23 +23,9 @@ public class PrintingToMultiplayer extends PhaseBase {
 	private static final int POSITION_CHECKS_PER_TICK = 8_192;
 
 	private Deque<MultiplayerPrintCommands.Command> remaining;
-	private boolean success;
 
 	@Override
 	public void whenEntered() {
-		// check for permissions for the setblock command
-		//? if >=1.21.11 {
-		if (!Minecraft.getInstance().player.permissions().hasPermission(net.minecraft.server.permissions.Permissions.COMMANDS_GAMEMASTER)) {
-		//?} else {
-		/*if (!Minecraft.getInstance().player.hasPermissions(2)) {
-		*///?}
-			success = false;
-
-			return;
-		}
-
-		success = true;
-
 		// Printing deliberately does NOT touch the server's gamerules. It used to turn off
 		// sendCommandFeedback and logAdminCommands and turn them back on afterwards, which
 		// silently disabled the server's admin-command audit log for everyone, and left it
@@ -57,19 +43,6 @@ public class PrintingToMultiplayer extends PhaseBase {
 
 	@Override
 	public void update() {
-		// exit state if not successful
-		if (!success) {
-			//? if >=26 {
-			Minecraft.getInstance().player.sendSystemMessage(Component.literal(
-							ChatFormatting.RED + "You do not have permission to print on this server."));
-			//?} else {
-			/*Minecraft.getInstance().player.displayClientMessage(Component.literal(
-							ChatFormatting.RED + "You do not have permission to print on this server."), false);
-			*///?}
-			ArchitectManager.enterPhase(ArchitectPhases.Previewing);
-			return;
-		}
-
 		int sent = 0;
 		int checked = 0;
 		while (sent < COMMANDS_PER_TICK && checked < POSITION_CHECKS_PER_TICK) {
@@ -110,14 +83,12 @@ public class PrintingToMultiplayer extends PhaseBase {
 
 	@Override
 	public void whenExited() {
-		if (success) {
-			//? if >=26 {
-			Minecraft.getInstance().player.sendSystemMessage(Component.literal(ChatFormatting.GREEN + "Finished Printing, enjoy!"));
-			//?} else {
-			/*Minecraft.getInstance().player.displayClientMessage(Component.literal(ChatFormatting.GREEN + "Finished Printing, enjoy!"),
-					false);
-			*///?}
-		}
+		//? if >=26 {
+		Minecraft.getInstance().player.sendSystemMessage(Component.literal(ChatFormatting.GREEN + "Finished Printing, enjoy!"));
+		//?} else {
+		/*Minecraft.getInstance().player.displayClientMessage(Component.literal(ChatFormatting.GREEN + "Finished Printing, enjoy!"),
+				false);
+		*///?}
 	}
 
 	@Override

--- a/common/src/main/java/com/timmie/mightyarchitect/platform/PacketSender.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/platform/PacketSender.java
@@ -1,11 +1,12 @@
 package com.timmie.mightyarchitect.platform;
 
 /**
- * Client-to-server delivery, supplied by the loader (Fabric's ClientPlayNetworking, NeoForge's
- * PacketDistributor, Forge's SimpleChannel).
+ * Client-to-server capability and delivery, supplied by the loader (Fabric's
+ * ClientPlayNetworking, NeoForge's NetworkRegistry/PacketDistributor, Forge's SimpleChannel).
  */
-@FunctionalInterface
 public interface PacketSender {
+
+	boolean canSendToServer(MightyPacket packet);
 
 	void sendToServer(MightyPacket packet);
 }

--- a/fabric/src/main/java/com/timmie/mightyarchitect/fabric/TheMightyArchitectFabricClient.java
+++ b/fabric/src/main/java/com/timmie/mightyarchitect/fabric/TheMightyArchitectFabricClient.java
@@ -3,6 +3,8 @@ package com.timmie.mightyarchitect.fabric;
 import com.timmie.mightyarchitect.AllPackets;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.platform.Env;
+import com.timmie.mightyarchitect.platform.MightyPacket;
+import com.timmie.mightyarchitect.platform.PacketSender;
 import net.fabricmc.api.ClientModInitializer;
 //? if >=26 {
 import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
@@ -29,18 +31,31 @@ public class TheMightyArchitectFabricClient implements ClientModInitializer {
 		KeyBindingHelper.registerKeyBinding(MightyClient.TOOL_MENU);
 		*///?}
 
-		// Before 1.20.5 there is no payload type to send: packets go out as a raw buffer on a
-		// named channel, so the mod serialises them itself.
-		//? if >=1.20.5 {
-		AllPackets.setSender(ClientPlayNetworking::send);
-		//?} else {
-		/*AllPackets.setSender(packet -> {
+		AllPackets.setSender(new PacketSender() {
+			@Override
+			public boolean canSendToServer(MightyPacket packet) {
+				//? if >=1.20.5 {
+				return ClientPlayNetworking.canSend(packet.type());
+				//?} else {
+				/*return ClientPlayNetworking.canSend(packet.id());
+				*///?}
+			}
+
+			@Override
+			public void sendToServer(MightyPacket packet) {
+				// Before 1.20.5 there is no payload type to send: packets go out as a raw buffer on
+				// a named channel, so the mod serialises them itself.
+				//? if >=1.20.5 {
+				ClientPlayNetworking.send(packet);
+				//?} else {
+				/*
 			net.minecraft.network.FriendlyByteBuf buffer =
 				net.fabricmc.fabric.api.networking.v1.PacketByteBufs.create();
 			packet.write(buffer);
 			ClientPlayNetworking.send(packet.id(), buffer);
+				*///?}
+			}
 		});
-		*///?}
 
 		OnRenderWorld.RegisterRenderEvent();
 	}

--- a/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForge.java
+++ b/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForge.java
@@ -8,6 +8,7 @@ import com.timmie.mightyarchitect.networking.SetHotbarItemPacket;
 import com.timmie.mightyarchitect.platform.MightyPacket;
 import com.timmie.mightyarchitect.platform.PacketContext;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.network.Connection;
 import net.minecraft.network.FriendlyByteBuf;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
@@ -69,8 +70,14 @@ public class TheMightyArchitectForge {
 			PlaceSignPacket::handle);
 		register(index++, SetHotbarItemPacket.class, AllPackets.SET_HOTBAR_ITEM_DECODER,
 			SetHotbarItemPacket::handle);
+	}
 
-		AllPackets.setSender(CHANNEL::sendToServer);
+	public static boolean canSendToServer(Connection connection) {
+		return CHANNEL.isRemotePresent(connection);
+	}
+
+	public static void sendToServer(MightyPacket packet) {
+		CHANNEL.sendToServer(packet);
 	}
 
 	private static <T extends MightyPacket> void register(int index, Class<T> type,

--- a/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
+++ b/forge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
@@ -1,7 +1,11 @@
 package com.timmie.mightyarchitect.forge;
 
+import com.timmie.mightyarchitect.AllPackets;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.platform.Env;
+import com.timmie.mightyarchitect.platform.MightyPacket;
+import com.timmie.mightyarchitect.platform.PacketSender;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RegisterKeyMappingsEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -20,6 +24,20 @@ public class TheMightyArchitectForgeClient {
 		// before Options is built - which is exactly when Forge fires this event.
 		Env.setClient(true);
 		MightyClient.init();
+		AllPackets.setSender(new PacketSender() {
+			@Override
+			public boolean canSendToServer(MightyPacket packet) {
+				if (Minecraft.getInstance().getConnection() == null)
+					return false;
+				return TheMightyArchitectForge.canSendToServer(
+					Minecraft.getInstance().getConnection().getConnection());
+			}
+
+			@Override
+			public void sendToServer(MightyPacket packet) {
+				TheMightyArchitectForge.sendToServer(packet);
+			}
+		});
 
 		event.register(MightyClient.COMPOSE);
 		event.register(MightyClient.TOOL_MENU);

--- a/neoforge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
+++ b/neoforge/src/main/java/com/timmie/mightyarchitect/forge/TheMightyArchitectForgeClient.java
@@ -3,6 +3,9 @@ package com.timmie.mightyarchitect.forge;
 import com.timmie.mightyarchitect.AllPackets;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.platform.Env;
+import com.timmie.mightyarchitect.platform.MightyPacket;
+import com.timmie.mightyarchitect.platform.PacketSender;
+import net.minecraft.client.Minecraft;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.common.Mod;
@@ -12,6 +15,7 @@ import net.neoforged.neoforge.client.network.ClientPacketDistributor;
 /*import net.neoforged.neoforge.network.PacketDistributor;
 *///?}
 import net.neoforged.neoforge.client.event.RegisterKeyMappingsEvent;
+import net.neoforged.neoforge.network.registration.NetworkRegistry;
 
 // From 20.5 FML constructs this only on the physical client, which is also how the mod learns its
 // side without reaching into loader internals. 20.4's @Mod has no dist attribute, so there the main
@@ -32,16 +36,37 @@ public class TheMightyArchitectForgeClient {
 		// Options is being built - so build them here rather than in a setup listener.
 		MightyClient.init();
 
-		// The client-side distributor moved to its own class in 21.8, and before 1.20.5 there is no
-		// payload-level send at all - the payload has to be wrapped in the vanilla packet first.
-		//? if >=1.21.8 {
-		AllPackets.setSender(ClientPacketDistributor::sendToServer);
-		//?} else if >=1.20.5 {
-		/*AllPackets.setSender(PacketDistributor::sendToServer);
-		*///?} else {
-		/*AllPackets.setSender(packet -> PacketDistributor.SERVER.noArg()
-			.send(new net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket(packet)));
-		*///?}
+		AllPackets.setSender(new PacketSender() {
+			@Override
+			public boolean canSendToServer(MightyPacket packet) {
+				if (Minecraft.getInstance().getConnection() == null)
+					return false;
+
+				// 20.4 predates the static channel query. Its packet check asks the same question
+				// after wrapping the payload in the vanilla serverbound packet.
+				//? if >=1.20.5 {
+				return NetworkRegistry.hasChannel(Minecraft.getInstance().getConnection(), packet.type().id());
+				//?} else {
+				/*return NetworkRegistry.getInstance().canSendPacket(
+					new net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket(packet),
+					Minecraft.getInstance().getConnection());
+				*///?}
+			}
+
+			@Override
+			public void sendToServer(MightyPacket packet) {
+				// The client-side distributor moved to its own class in 21.8, and before 1.20.5
+				// payloads have to be wrapped in the vanilla packet first.
+				//? if >=1.21.8 {
+				ClientPacketDistributor.sendToServer(packet);
+				//?} else if >=1.20.5 {
+				/*PacketDistributor.sendToServer(packet);
+				*///?} else {
+				/*PacketDistributor.SERVER.noArg()
+					.send(new net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket(packet));
+				*///?}
+			}
+		});
 
 		modEventBus.addListener(TheMightyArchitectForgeClient::registerKeyMappings);
 	}

--- a/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/MultiplayerPrintCommandsTest.java
+++ b/unit-test/src/main/java/com/timmie/mightyarchitect/test/unit/MultiplayerPrintCommandsTest.java
@@ -1,0 +1,114 @@
+package com.timmie.mightyarchitect.test.unit;
+
+import com.timmie.mightyarchitect.control.phase.MultiplayerPrintCommands;
+import com.timmie.mightyarchitect.control.phase.MultiplayerPrintCommands.Command;
+import com.timmie.mightyarchitect.test.unit.MinecraftBootstrap.Bootstrapped;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Bootstrapped
+@DisplayName("Multiplayer command fallback")
+class MultiplayerPrintCommandsTest {
+
+    @Test
+    @DisplayName("a singleton uses canonical block-state serialization")
+    void singletonUsesSetblock() {
+        Command command = onlyCommand(Map.of(new BlockPos(3, 7, -2), Blocks.STONE.defaultBlockState()));
+
+        assertEquals("setblock 3 7 -2 minecraft:stone", command.text());
+        assertEquals(1, command.blockCount());
+    }
+
+    @Test
+    @DisplayName("contiguous equal states become one fill command")
+    void contiguousRunUsesFill() {
+        Map<BlockPos, BlockState> blocks = new HashMap<>();
+        for (int z = 5; z <= 9; z++)
+            blocks.put(new BlockPos(2, 4, z), Blocks.OAK_PLANKS.defaultBlockState());
+
+        Command command = onlyCommand(blocks);
+
+        assertEquals("fill 2 4 5 2 4 9 minecraft:oak_planks", command.text());
+        assertEquals(5, command.blockCount());
+    }
+
+    @Test
+    @DisplayName("runs never merge across gaps or block states")
+    void gapsAndStatesStaySeparate() {
+        Map<BlockPos, BlockState> blocks = new HashMap<>();
+        blocks.put(new BlockPos(0, 0, 0), Blocks.STONE.defaultBlockState());
+        blocks.put(new BlockPos(1, 0, 0), Blocks.STONE.defaultBlockState());
+        blocks.put(new BlockPos(3, 0, 0), Blocks.STONE.defaultBlockState());
+        blocks.put(new BlockPos(4, 0, 0), Blocks.GLASS.defaultBlockState());
+
+        List<Command> commands = MultiplayerPrintCommands.plan(blocks);
+
+        assertEquals(3, commands.size());
+        assertEquals(4, commands.stream().mapToInt(Command::blockCount).sum());
+    }
+
+    @Test
+    @DisplayName("revalidation splits a queued fill around a newly blocked position")
+    void revalidationSplitsAQueuedFill() {
+        Map<BlockPos, BlockState> blocks = new HashMap<>();
+        for (int x = 0; x < 5; x++)
+            blocks.put(new BlockPos(x, 0, 0), Blocks.STONE.defaultBlockState());
+        Command queued = onlyCommand(blocks);
+
+        List<Command> current = MultiplayerPrintCommands.replan(queued, pos -> pos.getX() != 2);
+
+        assertEquals(2, current.size());
+        assertEquals("fill 0 0 0 1 0 0 minecraft:stone", current.get(0).text());
+        assertEquals("fill 3 0 0 4 0 0 minecraft:stone", current.get(1).text());
+    }
+
+    @Test
+    @DisplayName("long runs are split into conservative fill batches")
+    void longRunsAreBounded() {
+        Map<BlockPos, BlockState> blocks = new HashMap<>();
+        for (int x = 0; x < 70; x++)
+            blocks.put(new BlockPos(x, 0, 0), Blocks.STONE.defaultBlockState());
+
+        List<Command> commands = MultiplayerPrintCommands.plan(blocks);
+
+        assertEquals(List.of(32, 32, 6), commands.stream().map(Command::blockCount).toList());
+    }
+
+    @Test
+    @DisplayName("a solid volume is covered exactly once with far fewer commands")
+    void solidVolumeIsCompactedWithoutLosingBlocks() {
+        Map<BlockPos, BlockState> blocks = new HashMap<>();
+        for (int x = 0; x < 12; x++)
+            for (int y = 0; y < 4; y++)
+                for (int z = 0; z < 6; z++)
+                    blocks.put(new BlockPos(x, y, z), Blocks.BRICKS.defaultBlockState());
+
+        List<Command> commands = MultiplayerPrintCommands.plan(blocks);
+
+        assertEquals(blocks.size(), commands.stream().mapToInt(Command::blockCount).sum());
+        Set<BlockPos> covered = new HashSet<>();
+        commands.forEach(command -> command.positions().forEach(
+            pos -> assertTrue(covered.add(pos), () -> pos + " was covered twice")));
+        assertEquals(blocks.keySet(), covered);
+        assertTrue(commands.size() <= 24,
+            () -> "expected at most one command per x-run, got " + commands.size());
+    }
+
+    private static Command onlyCommand(Map<BlockPos, BlockState> blocks) {
+        List<Command> commands = MultiplayerPrintCommands.plan(blocks);
+        assertEquals(1, commands.size());
+        return commands.get(0);
+    }
+}


### PR DESCRIPTION
## Summary

- route multiplayer printing through `InstantPrintPacket` whenever the connected server advertises the mod's channel, across Fabric, NeoForge, and legacy Forge
- retain the command fallback for vanilla and modless servers, using `BlockStateParser.serialize` instead of `BlockState.toString()` scraping
- collapse contiguous equal-state runs into bounded `/fill` commands, send at most one command per tick, and revalidate world state, loaded chunks, bounds, and collisions immediately before each batch
- preserve existing block-entity data by leaving already-matching states untouched; the composer itself materializes block states only, so neither transport has source sign/container NBT to synthesize

## Verification

- `./gradlew compileAll`
- `./gradlew unitTestAll --max-workers=1`
- source-shape gate: 174 Java files, no whole-file guarded duplicates
- client matrix now asserts both channel advertisement and that a dedicated modded server selects the packet path
- mutation proof: [broken planner fails the build](https://github.com/TimStewartJ/TheMightyArchitectury/actions/runs/31648702935) and [one-line broken packet routing fails the client gate](https://github.com/TimStewartJ/TheMightyArchitectury/actions/runs/31652278656)
- feature matrix: [Build (all versions)](https://github.com/TimStewartJ/TheMightyArchitectury/actions/runs/31652258712)
