### PR TITLE
Add recorded real-input player journey

### DIFF
--- a/.github/workflows/player-journey.yml
+++ b/.github/workflows/player-journey.yml
@@ -1,0 +1,95 @@
+name: Recorded player journey
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/player-journey.yml"
+      - "client-test/**"
+      - "common/src/**"
+      - "fabric/**"
+      - "scripts/run-player-journey.ps1"
+      - "scripts/TestMatrix.Common.psm1"
+  pull_request:
+    paths:
+      - ".github/workflows/player-journey.yml"
+      - "client-test/**"
+      - "common/src/**"
+      - "fabric/**"
+      - "scripts/run-player-journey.ps1"
+      - "scripts/TestMatrix.Common.psm1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  record:
+    name: 1.20.2 Fabric recording
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: |
+            17
+            21
+            25
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Install virtual display, input, and recording tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb openbox xdotool ffmpeg libgl1 libgl1-mesa-dri mesa-utils
+
+      - name: Run recorded packaged-client journey
+        env:
+          CI: true
+          LIBGL_ALWAYS_SOFTWARE: "1"
+          ALSOFT_DRIVERS: "null"
+        run: |
+          chmod +x ./gradlew
+          xvfb-run -a -s "-screen 0 1280x720x24" bash -c '
+            cat >/tmp/openbox-rc.xml <<EOF
+          <openbox_config xmlns="http://openbox.org/3.4/rc">
+            <applications>
+              <application class="*"><decor>no</decor></application>
+            </applications>
+          </openbox_config>
+          EOF
+            openbox --config-file /tmp/openbox-rc.xml >/tmp/openbox.log 2>&1 &
+            pwsh -NoProfile -File ./scripts/run-player-journey.ps1
+          '
+
+      - name: Add journey summary
+        if: always()
+        run: |
+          summary="build/player-journey-results/1.20.2-fabric/summary.md"
+          if [ -f "$summary" ]; then
+            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "## Recorded player journey" >> "$GITHUB_STEP_SUMMARY"
+            echo "No result summary was produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload recording and evidence
+        id: evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: player-journey-1.20.2-fabric
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+          path: build/player-journey-results/1.20.2-fabric/
+
+      - name: Link recording
+        if: always() && steps.evidence.outputs.artifact-url != ''
+        run: echo "[Download the MP4 recording and evidence bundle](${{ steps.evidence.outputs.artifact-url }})" >> "$GITHUB_STEP_SUMMARY"

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestEntrypoint.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/ClientTestEntrypoint.java
@@ -1,0 +1,12 @@
+package com.timmie.mightyarchitect.test;
+
+public final class ClientTestEntrypoint {
+
+    private ClientTestEntrypoint() {
+    }
+
+    public static void start() {
+        ClientTestController.start();
+        PlayerJourneyController.start();
+    }
+}

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/PlayerJourneyController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/PlayerJourneyController.java
@@ -12,9 +12,12 @@ import com.timmie.mightyarchitect.control.palette.PaletteStorage;
 import com.timmie.mightyarchitect.foundation.compat.McCompat;
 import com.timmie.mightyarchitect.foundation.compat.ServerConnect;
 import com.timmie.mightyarchitect.gui.PalettePickerScreen;
+import com.timmie.mightyarchitect.gui.ArchitectMenuScreen;
+import com.timmie.mightyarchitect.gui.TextInputPromptScreen;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.ChatScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
@@ -169,7 +172,7 @@ public final class PlayerJourneyController {
             state.addProperty("paletteTargetY", (Number) null);
 
             Screen screen = McCompat.currentScreen(minecraft);
-            String screenName = screen == null ? "" : screen.getClass().getSimpleName();
+            String screenName = screenName(screen);
             state.addProperty("screen", screenName);
             String phase = ArchitectManager.getPhase().name();
             state.addProperty("phase", phase);
@@ -251,6 +254,7 @@ public final class PlayerJourneyController {
                 continue;
             buttons.add(widget);
         }
+
         buttons.sort(Comparator.comparingInt(AbstractWidget::getY).thenComparingInt(AbstractWidget::getX));
         List<String> paletteNames = PaletteStorage.getResourcePaletteNames();
         int targetIndex = -1;
@@ -270,6 +274,20 @@ public final class PlayerJourneyController {
         state.addProperty("paletteTargetX", (target.getX() + target.getWidth() / 2.0) * scale);
         state.addProperty("paletteTargetY", (target.getY() + target.getHeight() / 2.0) * scale);
         state.addProperty("paletteTargetName", paletteNames.get(targetIndex));
+    }
+
+    private static String screenName(Screen screen) {
+        if (screen == null)
+            return "";
+        if (screen instanceof ArchitectMenuScreen)
+            return "ArchitectMenuScreen";
+        if (screen instanceof PalettePickerScreen)
+            return "PalettePickerScreen";
+        if (screen instanceof TextInputPromptScreen)
+            return "TextInputPromptScreen";
+        if (screen instanceof ChatScreen)
+            return "ChatScreen";
+        return screen.getClass().getSimpleName();
     }
 
     private static void deleteState() {

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/PlayerJourneyController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/PlayerJourneyController.java
@@ -1,0 +1,299 @@
+package com.timmie.mightyarchitect.test;
+
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.timmie.mightyarchitect.MightyClient;
+import com.timmie.mightyarchitect.TheMightyArchitect;
+import com.timmie.mightyarchitect.control.ArchitectManager;
+import com.timmie.mightyarchitect.control.Schematic;
+import com.timmie.mightyarchitect.control.TemplateBlockAccess;
+import com.timmie.mightyarchitect.control.compose.GroundPlan;
+import com.timmie.mightyarchitect.control.palette.PaletteStorage;
+import com.timmie.mightyarchitect.foundation.compat.McCompat;
+import com.timmie.mightyarchitect.foundation.compat.ServerConnect;
+import com.timmie.mightyarchitect.gui.PalettePickerScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Passive state observer for the externally driven player journey.
+ * <p>
+ * This class deliberately performs no architect action. The PowerShell driver sends XTEST input
+ * through Minecraft's real GLFW callbacks; this companion only reports what the game did with it.
+ * Connecting to the local fixture server is setup, before the recorded player journey begins.
+ */
+public final class PlayerJourneyController {
+
+    private static final int STATE_WRITE_INTERVAL_TICKS = 2;
+    private static final int CONNECT_AFTER_TICKS = 20;
+
+    private static boolean started;
+    private static boolean connecting;
+    private static int ticks;
+    private static int keyEvents;
+    private static int mouseButtonEvents;
+    private static int scrollEvents;
+    private static int lastKey = -1;
+    private static int lastKeyAction = -1;
+    private static int lastMouseButton = -1;
+    private static int lastMouseAction = -1;
+    private static double lastHorizontalScroll;
+    private static double lastVerticalScroll;
+    private static String previousPhase = "";
+    private static String previousScreen = "";
+    private static final Map<BlockPos, BlockState> expectedPrintedBlocks = new LinkedHashMap<>();
+    private static Schematic capturedModel;
+    private static Object capturedPrimaryPalette;
+    private static Object capturedSecondaryPalette;
+
+    private PlayerJourneyController() {
+    }
+
+    public static void start() {
+        if (!Boolean.getBoolean("mightyarchitect.playerJourney.enabled") || started)
+            return;
+
+        started = true;
+        deleteState();
+        TheMightyArchitect.logger.info("[PLAYER-JOURNEY] Passive observer started");
+    }
+
+    public static void tick(Minecraft minecraft) {
+        if (!started)
+            return;
+
+        ticks++;
+        if (minecraft.level == null || minecraft.player == null) {
+            connect(minecraft);
+        } else {
+            captureExpectedPrint(minecraft);
+        }
+
+        if (ticks % STATE_WRITE_INTERVAL_TICKS == 0)
+            writeState(minecraft);
+    }
+
+    public static void recordKey(int key, int action) {
+        if (!started)
+            return;
+        keyEvents++;
+        lastKey = key;
+        lastKeyAction = action;
+    }
+
+    public static void recordMouseButton(int button, int action) {
+        if (!started)
+            return;
+        mouseButtonEvents++;
+        lastMouseButton = button;
+        lastMouseAction = action;
+    }
+
+    public static void recordScroll(double horizontal, double vertical) {
+        if (!started)
+            return;
+        scrollEvents++;
+        lastHorizontalScroll = horizontal;
+        lastVerticalScroll = vertical;
+    }
+
+    private static void connect(Minecraft minecraft) {
+        if (connecting || ticks < CONNECT_AFTER_TICKS || McCompat.hasOverlay(minecraft))
+            return;
+
+        String server = System.getProperty("mightyarchitect.playerJourney.server", "127.0.0.1:25565");
+        ServerAddress address = ServerAddress.parseString(server);
+        ServerData data = ServerConnect.serverData("Mighty Architect Player Journey", server);
+        connecting = true;
+        TheMightyArchitect.logger.info("[PLAYER-JOURNEY] Connecting to {}", server);
+        ServerConnect.connect(minecraft, McCompat.currentScreen(minecraft), address, data);
+    }
+
+    private static void captureExpectedPrint(Minecraft minecraft) {
+        Schematic model = ArchitectManager.getModel();
+        if (model.getSketch() == null || model.isMaterializing() || model.getAnchor() == null)
+            return;
+
+        TemplateBlockAccess materialized = model.getMaterializedSketch();
+        if (materialized == null || materialized.getBlockMap().isEmpty())
+            return;
+        if (model == capturedModel && model.getPrimary() == capturedPrimaryPalette
+            && model.getSecondary() == capturedSecondaryPalette)
+            return;
+
+        expectedPrintedBlocks.clear();
+        materialized.getBlockMap().forEach((local, state) ->
+            expectedPrintedBlocks.put(local.offset(model.getAnchor()), state));
+        capturedModel = model;
+        capturedPrimaryPalette = model.getPrimary();
+        capturedSecondaryPalette = model.getSecondary();
+    }
+
+    private static void writeState(Minecraft minecraft) {
+        try {
+            JsonObject state = new JsonObject();
+            state.addProperty("tick", ticks);
+            boolean worldReady = minecraft.level != null && minecraft.player != null;
+            state.addProperty("worldReady", worldReady);
+            state.addProperty("overlayVisible", McCompat.hasOverlay(minecraft));
+            state.addProperty("keyEvents", keyEvents);
+            state.addProperty("mouseButtonEvents", mouseButtonEvents);
+            state.addProperty("scrollEvents", scrollEvents);
+            state.addProperty("lastKey", lastKey);
+            state.addProperty("lastKeyAction", lastKeyAction);
+            state.addProperty("lastMouseButton", lastMouseButton);
+            state.addProperty("lastMouseAction", lastMouseAction);
+            state.addProperty("lastHorizontalScroll", lastHorizontalScroll);
+            state.addProperty("lastVerticalScroll", lastVerticalScroll);
+            state.addProperty("targetX", (Number) null);
+            state.addProperty("targetY", (Number) null);
+            state.addProperty("targetZ", (Number) null);
+            state.addProperty("paletteTargetX", (Number) null);
+            state.addProperty("paletteTargetY", (Number) null);
+
+            Screen screen = McCompat.currentScreen(minecraft);
+            String screenName = screen == null ? "" : screen.getClass().getSimpleName();
+            state.addProperty("screen", screenName);
+            String phase = ArchitectManager.getPhase().name();
+            state.addProperty("phase", phase);
+
+            if (!phase.equals(previousPhase) || !screenName.equals(previousScreen)) {
+                TheMightyArchitect.logger.info("[PLAYER-JOURNEY] State phase={} screen={}", phase,
+                    screenName.isEmpty() ? "<none>" : screenName);
+                previousPhase = phase;
+                previousScreen = screenName;
+            }
+
+            if (worldReady) {
+                state.addProperty("selectedHotbarSlot", McCompat.selectedHotbarSlot(minecraft.player));
+                state.addProperty("playerX", minecraft.player.getX());
+                state.addProperty("playerY", minecraft.player.getY());
+                state.addProperty("playerZ", minecraft.player.getZ());
+                state.addProperty("playerYaw", minecraft.player.getYRot());
+                state.addProperty("playerPitch", minecraft.player.getXRot());
+                state.addProperty("gameMode", minecraft.gameMode.getPlayerMode().toString());
+
+                if (minecraft.hitResult instanceof BlockHitResult blockHit) {
+                    BlockPos target = blockHit.getBlockPos();
+                    state.addProperty("targetX", target.getX());
+                    state.addProperty("targetY", target.getY());
+                    state.addProperty("targetZ", target.getZ());
+                }
+
+                Schematic model = ArchitectManager.getModel();
+                GroundPlan groundPlan = model.getGroundPlan();
+                int[] roomCount = { 0 };
+                if (groundPlan != null)
+                    groundPlan.forEachRoom(room -> roomCount[0]++);
+                state.addProperty("roomCount", roomCount[0]);
+                state.addProperty("themeName",
+                    groundPlan == null ? "" : groundPlan.theme.getDisplayName());
+                state.addProperty("sketchPresent", model.getSketch() != null);
+                state.addProperty("materializing", model.isMaterializing());
+                state.addProperty("rendererGeometry", MightyClient.renderer.hasGeometry());
+                state.addProperty("paletteName",
+                    model.getPrimary() == null ? "" : model.getPrimary().getName());
+
+                int previewBlocks = 0;
+                if (model.getSketch() != null && !model.isMaterializing()
+                    && model.getMaterializedSketch() != null) {
+                    previewBlocks = model.getMaterializedSketch().getBlockMap().size();
+                }
+                state.addProperty("previewBlocks", previewBlocks);
+
+                int matches = 0;
+                for (Map.Entry<BlockPos, BlockState> expected : expectedPrintedBlocks.entrySet())
+                    if (minecraft.level.getBlockState(expected.getKey()).equals(expected.getValue()))
+                        matches++;
+                state.addProperty("expectedPrintedBlocks", expectedPrintedBlocks.size());
+                state.addProperty("matchingPrintedBlocks", matches);
+                state.addProperty("printedWorldMatches",
+                    !expectedPrintedBlocks.isEmpty() && matches == expectedPrintedBlocks.size());
+            }
+
+            addPaletteTarget(state, minecraft, screen);
+            writeJsonAtomically(statePath(), state);
+        } catch (Throwable throwable) {
+            TheMightyArchitect.logger.error("[PLAYER-JOURNEY] Unable to write observer state", throwable);
+        }
+    }
+
+    private static void addPaletteTarget(JsonObject state, Minecraft minecraft, Screen screen) {
+        if (!(screen instanceof PalettePickerScreen))
+            return;
+
+        int gridX = (minecraft.getWindow().getGuiScaledWidth() - 256) / 2 + 10;
+        int gridY = (minecraft.getWindow().getGuiScaledHeight() - 236) / 2 + 68;
+        List<AbstractWidget> buttons = new ArrayList<>();
+        for (GuiEventListener child : screen.children()) {
+            if (!(child instanceof AbstractWidget widget) || !widget.active || !widget.visible)
+                continue;
+            if (widget.getX() < gridX || widget.getX() >= gridX + 5 * 23)
+                continue;
+            if (widget.getY() < gridY || widget.getY() >= gridY + 4 * 23)
+                continue;
+            buttons.add(widget);
+        }
+        buttons.sort(Comparator.comparingInt(AbstractWidget::getY).thenComparingInt(AbstractWidget::getX));
+        List<String> paletteNames = PaletteStorage.getResourcePaletteNames();
+        int targetIndex = -1;
+        String currentName = ArchitectManager.getModel().getPrimary() == null
+            ? "" : ArchitectManager.getModel().getPrimary().getName();
+        for (int i = 0; i < paletteNames.size() && i < buttons.size(); i++) {
+            if (!paletteNames.get(i).equals(currentName)) {
+                targetIndex = i;
+                break;
+            }
+        }
+        if (targetIndex < 0)
+            return;
+
+        AbstractWidget target = buttons.get(targetIndex);
+        double scale = minecraft.getWindow().getGuiScale();
+        state.addProperty("paletteTargetX", (target.getX() + target.getWidth() / 2.0) * scale);
+        state.addProperty("paletteTargetY", (target.getY() + target.getHeight() / 2.0) * scale);
+        state.addProperty("paletteTargetName", paletteNames.get(targetIndex));
+    }
+
+    private static void deleteState() {
+        try {
+            Files.deleteIfExists(statePath());
+        } catch (Exception exception) {
+            throw new IllegalStateException("Unable to remove stale player-journey state", exception);
+        }
+    }
+
+    private static Path statePath() {
+        String configured = System.getProperty("mightyarchitect.playerJourney.state");
+        if (configured == null || configured.isBlank())
+            throw new IllegalStateException("mightyarchitect.playerJourney.state is not configured");
+        return Path.of(configured);
+    }
+
+    private static void writeJsonAtomically(Path path, JsonObject json) throws Exception {
+        if (path.getParent() != null)
+            Files.createDirectories(path.getParent());
+        Path temporary = path.resolveSibling(path.getFileName() + ".tmp");
+        Files.writeString(temporary, new GsonBuilder().setPrettyPrinting().create().toJson(json),
+            StandardCharsets.UTF_8);
+        Files.move(temporary, path, StandardCopyOption.REPLACE_EXISTING,
+            StandardCopyOption.ATOMIC_MOVE);
+    }
+}

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/PlayerJourneyController.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/PlayerJourneyController.java
@@ -1,6 +1,7 @@
 package com.timmie.mightyarchitect.test;
 
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.TheMightyArchitect;
@@ -222,13 +223,27 @@ public final class PlayerJourneyController {
                 state.addProperty("previewBlocks", previewBlocks);
 
                 int matches = 0;
-                for (Map.Entry<BlockPos, BlockState> expected : expectedPrintedBlocks.entrySet())
-                    if (minecraft.level.getBlockState(expected.getKey()).equals(expected.getValue()))
+                int blockMatches = 0;
+                JsonArray mismatchSamples = new JsonArray();
+                for (Map.Entry<BlockPos, BlockState> expected : expectedPrintedBlocks.entrySet()) {
+                    BlockState actual = minecraft.level.getBlockState(expected.getKey());
+                    if (actual.getBlock() == expected.getValue().getBlock())
+                        blockMatches++;
+                    if (actual.equals(expected.getValue())) {
                         matches++;
+                    } else if (mismatchSamples.size() < 8) {
+                        mismatchSamples.add(expected.getKey() + ": expected " + expected.getValue()
+                            + ", found " + actual);
+                    }
+                }
                 state.addProperty("expectedPrintedBlocks", expectedPrintedBlocks.size());
+                state.addProperty("matchingPrintedBlockTypes", blockMatches);
                 state.addProperty("matchingPrintedBlocks", matches);
+                state.addProperty("printedWorldBlockTypesMatch",
+                    !expectedPrintedBlocks.isEmpty() && blockMatches == expectedPrintedBlocks.size());
                 state.addProperty("printedWorldMatches",
                     !expectedPrintedBlocks.isEmpty() && matches == expectedPrintedBlocks.size());
+                state.add("printedStateMismatchSamples", mismatchSamples);
             }
 
             addPaletteTarget(state, minecraft, screen);

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/mixin/ClientHooksProbeMixin.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/mixin/ClientHooksProbeMixin.java
@@ -1,0 +1,29 @@
+package com.timmie.mightyarchitect.test.mixin;
+
+import com.timmie.mightyarchitect.platform.ClientHooks;
+import com.timmie.mightyarchitect.test.PlayerJourneyController;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(value = ClientHooks.class, remap = false)
+public abstract class ClientHooksProbeMixin {
+
+    @Inject(method = "mouseScrolled", at = @At("HEAD"), remap = false)
+    private static void mightyarchitectTest$recordScroll(double horizontal, double vertical,
+                                                         CallbackInfoReturnable<Boolean> callback) {
+        PlayerJourneyController.recordScroll(horizontal, vertical);
+    }
+
+    @Inject(method = "mouseClicked", at = @At("HEAD"), remap = false)
+    private static void mightyarchitectTest$recordClick(int button, int action, CallbackInfo callback) {
+        PlayerJourneyController.recordMouseButton(button, action);
+    }
+
+    @Inject(method = "keyPressed", at = @At("HEAD"), remap = false)
+    private static void mightyarchitectTest$recordKey(int key, int action, CallbackInfo callback) {
+        PlayerJourneyController.recordKey(key, action);
+    }
+}

--- a/client-test/src/main/java/com/timmie/mightyarchitect/test/mixin/MightyClientProbeMixin.java
+++ b/client-test/src/main/java/com/timmie/mightyarchitect/test/mixin/MightyClientProbeMixin.java
@@ -2,6 +2,7 @@ package com.timmie.mightyarchitect.test.mixin;
 
 import com.timmie.mightyarchitect.MightyClient;
 import com.timmie.mightyarchitect.test.ClientTestController;
+import com.timmie.mightyarchitect.test.PlayerJourneyController;
 import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -21,5 +22,6 @@ public abstract class MightyClientProbeMixin {
     @Inject(method = "onTick", at = @At("HEAD"), remap = false)
     private static void mightyarchitectTest$tick(Minecraft minecraft, CallbackInfo callback) {
         ClientTestController.tick(minecraft);
+        PlayerJourneyController.tick(minecraft);
     }
 }

--- a/client-test/src/main/resources/mightyarchitect-test.mixins.json
+++ b/client-test/src/main/resources/mightyarchitect-test.mixins.json
@@ -6,6 +6,7 @@
   "client": [
     "ArchitectManagerProbeMixin",
     "ArchitectManagerAccessor",
+    "ClientHooksProbeMixin",
     "MightyClientProbeMixin",
     "PhaseComposingProbeMixin"
   ],

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
@@ -170,7 +170,7 @@ public final class McCompat {
 	}
 
 	public static int selectedHotbarSlot(LocalPlayer player) {
-		//? if >=1.21.10 {
+		//? if >=1.21.6 {
 		return player.getInventory().getSelectedSlot();
 		//?} else {
 		/*return player.getInventory().selected;

--- a/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
+++ b/common/src/main/java/com/timmie/mightyarchitect/foundation/compat/McCompat.java
@@ -19,6 +19,7 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 /*import com.timmie.mightyarchitect.foundation.gui.GuiGraphics;
 *///?}
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.player.LocalPlayer;
 import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 
@@ -165,6 +166,14 @@ public final class McCompat {
 		/*return mc.getModelManager()
 			.getBlockModelShaper()
 			.getBlockModel(net.minecraft.world.level.block.Blocks.STONE.defaultBlockState());
+		*///?}
+	}
+
+	public static int selectedHotbarSlot(LocalPlayer player) {
+		//? if >=1.21.10 {
+		return player.getInventory().getSelectedSlot();
+		//?} else {
+		/*return player.getInventory().selected;
 		*///?}
 	}
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -18,6 +18,10 @@ def prodClientTestRunDir = clientTestSessionId
 def prodClientTestResultFile = clientTestSessionId
     ? layout.buildDirectory.file("prod-client-test-${clientTestSessionId}/result.json")
     : layout.buildDirectory.file("prod-client-test/result.json")
+def playerJourneyRunDir = "run-player-journey"
+def playerJourneyStateFile = layout.buildDirectory.file("player-journey/state.json")
+def playerJourneyServer = (System.getenv("MIGHTYARCHITECT_PLAYER_JOURNEY_SERVER")
+    ?: "127.0.0.1:25566").toString()
 def clientTestServer = (System.getenv("MIGHTYARCHITECT_CLIENT_TEST_SERVER")
     ?: project.findProperty("clientTestServer")
     ?: "127.0.0.1:25565").toString()
@@ -299,6 +303,28 @@ tasks.register("runProductionClientTest", ClientProductionRunTask) {
 
     // javaLauncher is left on its convention, which is this project's own toolchain - the same
     // JDK the dev run and the node's compile use.
+}
+
+tasks.register("runProductionPlayerJourney", ClientProductionRunTask) {
+    group = "verification"
+    description = "Runs the packaged Fabric jars for an externally driven player journey."
+
+    mods.from packagedClientTestJar
+    runDir = layout.projectDirectory.dir(playerJourneyRunDir)
+
+    jvmArgs.addAll(
+        "-Dmightyarchitect.playerJourney.enabled=true",
+        "-Dmightyarchitect.playerJourney.server=${playerJourneyServer}".toString(),
+        "-Dmightyarchitect.playerJourney.state=${playerJourneyStateFile.get().asFile.absolutePath}".toString()
+    )
+
+    programArgs.addAll(
+        "--accessToken", "0",
+        "--version", "mightyarchitect-player-journey",
+        "--username", "ArchitectTest"
+    )
+
+    useXVFB = false
 }
 
 if (unobf) {

--- a/fabric/src/clientTest/java/com/timmie/mightyarchitect/test/fabric/MightyArchitectClientTestFabric.java
+++ b/fabric/src/clientTest/java/com/timmie/mightyarchitect/test/fabric/MightyArchitectClientTestFabric.java
@@ -1,12 +1,12 @@
 package com.timmie.mightyarchitect.test.fabric;
 
-import com.timmie.mightyarchitect.test.ClientTestController;
+import com.timmie.mightyarchitect.test.ClientTestEntrypoint;
 import net.fabricmc.api.ClientModInitializer;
 
 public class MightyArchitectClientTestFabric implements ClientModInitializer {
 
     @Override
     public void onInitializeClient() {
-        ClientTestController.start();
+        ClientTestEntrypoint.start();
     }
 }

--- a/forge/src/clientTest/java/com/timmie/mightyarchitect/test/forge/MightyArchitectClientTestForge.java
+++ b/forge/src/clientTest/java/com/timmie/mightyarchitect/test/forge/MightyArchitectClientTestForge.java
@@ -1,6 +1,6 @@
 package com.timmie.mightyarchitect.test.forge;
 
-import com.timmie.mightyarchitect.test.ClientTestController;
+import com.timmie.mightyarchitect.test.ClientTestEntrypoint;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.loading.FMLEnvironment;
@@ -10,6 +10,6 @@ public class MightyArchitectClientTestForge {
 
     public MightyArchitectClientTestForge() {
         if (FMLEnvironment.dist == Dist.CLIENT)
-            ClientTestController.start();
+            ClientTestEntrypoint.start();
     }
 }

--- a/neoforge/src/clientTest/java/com/timmie/mightyarchitect/test/neoforge/MightyArchitectClientTestNeoForge.java
+++ b/neoforge/src/clientTest/java/com/timmie/mightyarchitect/test/neoforge/MightyArchitectClientTestNeoForge.java
@@ -28,7 +28,7 @@ public class MightyArchitectClientTestNeoForge {
 
     private static void startClientTest() {
         try {
-            Class.forName("com.timmie.mightyarchitect.test.ClientTestController")
+            Class.forName("com.timmie.mightyarchitect.test.ClientTestEntrypoint")
                 .getMethod("start")
                 .invoke(null);
         } catch (ReflectiveOperationException exception) {

--- a/scripts/TestMatrix.Common.psm1
+++ b/scripts/TestMatrix.Common.psm1
@@ -273,6 +273,7 @@ function Start-TestVanillaServer {
     $jar = Get-TestServerJar -MinecraftVersion $minecraftVersion -RuntimeRoot $RuntimeRoot
     Set-Content (Join-Path $directory 'eula.txt') 'eula=true' -Encoding ascii
     $serverProperties = @(
+        'server-ip=127.0.0.1'
         "server-port=$Port"
         'online-mode=false'
         'enforce-secure-profile=false'

--- a/scripts/TestMatrix.Common.psm1
+++ b/scripts/TestMatrix.Common.psm1
@@ -259,7 +259,9 @@ function Start-TestVanillaServer {
         [int]$Port,
         [Parameter(Mandatory = $true)]
         [string]$Motd,
-        [int]$StartupTimeoutSeconds = 180
+        [int]$StartupTimeoutSeconds = 180,
+        [string]$OfflineOperator,
+        [switch]$Creative
     )
 
     $minecraftVersion = $Properties.minecraft_version
@@ -270,7 +272,7 @@ function Start-TestVanillaServer {
 
     $jar = Get-TestServerJar -MinecraftVersion $minecraftVersion -RuntimeRoot $RuntimeRoot
     Set-Content (Join-Path $directory 'eula.txt') 'eula=true' -Encoding ascii
-    @(
+    $serverProperties = @(
         "server-port=$Port"
         'online-mode=false'
         'enforce-secure-profile=false'
@@ -281,7 +283,25 @@ function Start-TestVanillaServer {
         'level-type=minecraft:flat'
         'difficulty=peaceful'
         "motd=$Motd"
-    ) | Set-Content (Join-Path $directory 'server.properties') -Encoding ascii
+    )
+    if ($Creative) {
+        $serverProperties += 'gamemode=creative'
+        $serverProperties += 'force-gamemode=true'
+    }
+    $serverProperties | Set-Content (Join-Path $directory 'server.properties') -Encoding ascii
+
+    if ($OfflineOperator) {
+        $operators = @(
+            [ordered]@{
+                uuid = Get-TestOfflineUuid -Name $OfflineOperator
+                name = $OfflineOperator
+                level = 4
+                bypassesPlayerLimit = $false
+            }
+        )
+        ConvertTo-Json -InputObject $operators |
+            Set-Content (Join-Path $directory 'ops.json') -Encoding utf8
+    }
 
     $stdout = Join-Path $directory 'server.stdout.log'
     $stderr = Join-Path $directory 'server.stderr.log'
@@ -303,6 +323,7 @@ function Start-TestVanillaServer {
             if ($process.HasExited) {
                 throw "Vanilla server $minecraftVersion exited early with code $($process.ExitCode)"
             }
+
             if (Test-Path $log) {
                 $text = Get-Content $log -Raw -ErrorAction SilentlyContinue
                 if ($text -match 'Done \(') {
@@ -321,6 +342,21 @@ function Start-TestVanillaServer {
         Stop-TestProcessTree -Process $process
         throw
     }
+}
+
+function Get-TestOfflineUuid {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name
+    )
+
+    $bytes = [Text.Encoding]::UTF8.GetBytes("OfflinePlayer:$Name")
+    $hash = [Security.Cryptography.MD5]::HashData($bytes)
+    $hash[6] = ($hash[6] -band 0x0f) -bor 0x30
+    $hash[8] = ($hash[8] -band 0x3f) -bor 0x80
+    $hex = -join ($hash | ForEach-Object { $_.ToString('x2') })
+    return '{0}-{1}-{2}-{3}-{4}' -f $hex.Substring(0, 8), $hex.Substring(8, 4),
+        $hex.Substring(12, 4), $hex.Substring(16, 4), $hex.Substring(20, 12)
 }
 
 function Get-TestHiddenWindowOption {
@@ -727,6 +763,7 @@ Export-ModuleMember -Function @(
     'Stop-TestOwnedProcess',
     'Write-TestSessionManifest',
     'Start-TestVanillaServer',
+    'Get-TestOfflineUuid',
     'Get-TestHiddenWindowOption',
     'Write-TestClientOptions',
     'Expand-TestListArgument',

--- a/scripts/run-player-journey.ps1
+++ b/scripts/run-player-journey.ps1
@@ -263,7 +263,7 @@ function Select-JourneyPalette {
         param($s)
         $s.screen -eq 'PalettePickerScreen' -and $s.paletteName -eq $picker.paletteTargetName
     } | Out-Null
-    Send-JourneyKey 'Escape'
+    Send-JourneyKey 'e'
     Wait-JourneyState 'palette picker closed back to preview' {
         param($s) $s.phase -eq 'Previewing' -and -not $s.screen
     } | Out-Null

--- a/scripts/run-player-journey.ps1
+++ b/scripts/run-player-journey.ps1
@@ -1,0 +1,456 @@
+[CmdletBinding()]
+param(
+    [string]$Version = '1.20.2',
+    [string]$Loader = 'fabric',
+    [int]$Port = 25566,
+    [int]$TimeoutSeconds = 900
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+if (-not $IsLinux) {
+    throw 'The recorded player journey currently requires Linux/X11 for xdotool and x11grab.'
+}
+if ($Loader -ne 'fabric') {
+    throw 'The initial recorded player journey supports the packaged Fabric client only.'
+}
+foreach ($command in @('ffmpeg', 'xdotool')) {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+        throw "$command is required for the recorded player journey."
+    }
+}
+if (-not $env:DISPLAY) {
+    throw 'DISPLAY is not set. Run this script inside Xvfb.'
+}
+
+Import-Module (Join-Path $PSScriptRoot 'TestMatrix.Common.psm1') -Force
+Assert-TestMatrixPowerShell
+
+$repoRoot = Get-TestMatrixRepoRoot -ScriptRoot $PSScriptRoot
+$properties = Get-TestNodeProperties -RepoRoot $repoRoot -Version $Version
+$gradle = Get-TestGradleCommand -RepoRoot $repoRoot
+$projectDirectory = Join-Path (Join-Path (Join-Path $repoRoot $Loader) 'versions') $Version
+$runDirectory = Join-Path $projectDirectory 'run-player-journey'
+$resultDirectory = Join-Path (Join-Path (Join-Path $repoRoot 'build') 'player-journey-results') "$Version-$Loader"
+$statePath = Join-Path (Join-Path $projectDirectory 'build') 'player-journey/state.json'
+$resultPath = Join-Path $resultDirectory 'result.json'
+$timelinePath = Join-Path $resultDirectory 'timeline.md'
+$videoPath = Join-Path $resultDirectory 'journey.mp4'
+$contactSheetPath = Join-Path $resultDirectory 'contact-sheet.png'
+$gradleStdout = Join-Path $resultDirectory 'gradle.stdout.log'
+$gradleStderr = Join-Path $resultDirectory 'gradle.stderr.log'
+$ffmpegLog = Join-Path $resultDirectory 'ffmpeg.log'
+$serverRuntimeRoot = Join-Path (Join-Path $repoRoot 'build') 'player-journey-runtime'
+$checks = [Collections.Generic.List[string]]::new()
+$timelineStart = Get-Date
+$clientProcess = $null
+$server = $null
+$recorder = $null
+$failure = $null
+
+Remove-Item $resultDirectory, $runDirectory -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item $statePath -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force -Path $resultDirectory | Out-Null
+Write-TestClientOptions -MinecraftDirectory $runDirectory
+Add-Content (Join-Path $runDirectory 'options.txt') @(
+    'rawMouseInput:false'
+    'overrideWidth:1280'
+    'overrideHeight:720'
+) -Encoding ascii
+
+@(
+    '# Player journey timeline'
+    ''
+    "| Time | Action |"
+    "| ---: | --- |"
+) | Set-Content $timelinePath -Encoding utf8
+
+function Add-JourneyTimeline {
+    param([string]$Action)
+
+    $elapsed = (Get-Date) - $timelineStart
+    $stamp = '{0:mm\:ss\.fff}' -f $elapsed
+    "| $stamp | $($Action.Replace('|', '\|')) |" | Add-Content $timelinePath -Encoding utf8
+    Write-Host "[$stamp] $Action"
+}
+
+function Read-JourneyState {
+    if (-not (Test-Path $statePath)) {
+        return $null
+    }
+    try {
+        return Get-Content $statePath -Raw | ConvertFrom-Json
+    } catch {
+        return $null
+    }
+}
+
+function Wait-JourneyState {
+    param(
+        [string]$Description,
+        [scriptblock]$Predicate,
+        [int]$Seconds = 120
+    )
+
+    $deadline = (Get-Date).AddSeconds($Seconds)
+    while ((Get-Date) -lt $deadline) {
+        if ($clientProcess -and $clientProcess.HasExited) {
+            $tail = if (Test-Path $gradleStdout) { (Get-Content $gradleStdout -Tail 40) -join "`n" } else { '' }
+            throw "Client exited while waiting for $Description (code $($clientProcess.ExitCode))`n$tail"
+        }
+        $state = Read-JourneyState
+        if ($state -and (& $Predicate $state)) {
+            Add-JourneyTimeline "Observed: $Description"
+            return $state
+        }
+        Start-Sleep -Milliseconds 250
+    }
+    $last = Read-JourneyState
+    throw "Timed out waiting for $Description. Last state: $($last | ConvertTo-Json -Compress)"
+}
+
+function Add-JourneyCheck {
+    param([string]$Description)
+    $checks.Add($Description)
+    Add-JourneyTimeline "PASS: $Description"
+}
+
+function Invoke-Xdotool {
+    param([string[]]$Arguments)
+    Add-JourneyTimeline "Input: xdotool $($Arguments -join ' ')"
+    & xdotool @Arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "xdotool exited ${LASTEXITCODE}: $($Arguments -join ' ')"
+    }
+}
+
+function Send-JourneyKey {
+    param([string]$Key)
+    Invoke-Xdotool -Arguments @('key', '--clearmodifiers', $Key)
+}
+
+function Send-JourneyText {
+    param([string]$Text)
+    Invoke-Xdotool -Arguments @('type', '--clearmodifiers', '--delay', '8', $Text)
+}
+
+function Send-JourneyCommand {
+    param([string]$Command)
+    Send-JourneyKey 't'
+    Wait-JourneyState 'chat screen opened' { param($s) $s.screen -match 'ChatScreen' } | Out-Null
+    Send-JourneyText $Command
+    Send-JourneyKey 'Return'
+    Wait-JourneyState 'chat command submitted' { param($s) -not $s.screen } | Out-Null
+}
+
+function Focus-JourneyWindow {
+    $deadline = (Get-Date).AddSeconds(180)
+    while ((Get-Date) -lt $deadline) {
+        $windowIds = @(& xdotool search --onlyvisible --name 'Minecraft' 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $windowIds.Count -gt 0) {
+            $windowId = "$($windowIds[-1])".Trim()
+            Invoke-Xdotool -Arguments @('windowactivate', '--sync', $windowId)
+            Invoke-Xdotool -Arguments @('windowsize', $windowId, '1280', '720')
+            Invoke-Xdotool -Arguments @('windowmove', $windowId, '0', '0')
+            return $windowId
+        }
+        Start-Sleep -Seconds 1
+    }
+    throw 'Minecraft window did not appear.'
+}
+
+function Get-JourneyWindowOrigin {
+    param([string]$WindowId)
+
+    $geometry = @(& xdotool getwindowgeometry --shell $WindowId)
+    $values = @{}
+    foreach ($line in $geometry) {
+        if ($line -match '^([^=]+)=(.*)$') {
+            $values[$matches[1]] = $matches[2]
+        }
+    }
+    if (-not $values.ContainsKey('X') -or -not $values.ContainsKey('Y')) {
+        throw "Unable to read window geometry for $WindowId"
+    }
+    return [pscustomobject]@{ X = [int]$values.X; Y = [int]$values.Y }
+}
+
+function Aim-JourneyAt {
+    param(
+        [int]$X,
+        [int]$Z
+    )
+
+    $xCoordinate = ($X + 0.5).ToString([Globalization.CultureInfo]::InvariantCulture)
+    $zCoordinate = ($Z + 0.5).ToString([Globalization.CultureInfo]::InvariantCulture)
+    Send-JourneyCommand "/tp ArchitectTest $xCoordinate 7 $zCoordinate 0 90"
+    Wait-JourneyState "crosshair targets $X,3,${Z}" {
+        param($s)
+        $null -ne $s.targetX -and [int]$s.targetX -eq $X -and [int]$s.targetY -eq 3 -and
+            [int]$s.targetZ -eq $Z
+    } | Out-Null
+}
+
+function Start-JourneyComposition {
+    Send-JourneyKey 'g'
+    Wait-JourneyState 'architect menu opened' { param($s) $s.screen -eq 'ArchitectMenuScreen' } | Out-Null
+    Send-JourneyKey '1'
+    Wait-JourneyState 'composer entered from theme selection' {
+        param($s)
+        $s.phase -eq 'Composing' -and -not $s.screen -and $s.themeName -eq 'Medieval'
+    } | Out-Null
+
+    Aim-JourneyAt -X 0 -Z 0
+    $before = Read-JourneyState
+    Invoke-Xdotool -Arguments @('click', '3')
+    Wait-JourneyState 'first room corner accepted through mouse hook' {
+        param($s)
+        [int]$s.mouseButtonEvents -gt [int]$before.mouseButtonEvents
+    } | Out-Null
+
+    Aim-JourneyAt -X 4 -Z 4
+    $before = Read-JourneyState
+    Invoke-Xdotool -Arguments @('click', '3')
+    Wait-JourneyState '5x5 room created' {
+        param($s)
+        [int]$s.mouseButtonEvents -gt [int]$before.mouseButtonEvents -and [int]$s.roomCount -eq 1
+    } | Out-Null
+
+    $before = Read-JourneyState
+    Invoke-Xdotool -Arguments @('click', '4')
+    $after = Wait-JourneyState 'room scroll added a floor without cycling the hotbar' {
+        param($s)
+        [int]$s.scrollEvents -gt [int]$before.scrollEvents -and [int]$s.roomCount -ge 2
+    }
+    if ([int]$after.selectedHotbarSlot -ne [int]$before.selectedHotbarSlot) {
+        throw "Composer scroll also changed hotbar slot $($before.selectedHotbarSlot) -> $($after.selectedHotbarSlot)"
+    }
+    Add-JourneyCheck 'real wheel input reached the production scroll hook and was consumed by the room tool'
+
+    Send-JourneyKey 'g'
+    Wait-JourneyState 'composer menu opened for finish' { param($s) $s.screen -eq 'ArchitectMenuScreen' } | Out-Null
+    Send-JourneyKey 'f'
+    Wait-JourneyState 'real ground plan generated a rendered preview' {
+        param($s)
+        $s.phase -eq 'Previewing' -and -not $s.screen -and [int]$s.previewBlocks -gt 0 -and
+            [bool]$s.rendererGeometry
+    } -Seconds 180 | Out-Null
+    Add-JourneyCheck 'theme selection, two world clicks, floor scroll, and finish produced a non-empty preview'
+}
+
+function Select-JourneyPalette {
+    param([string]$WindowId)
+
+    $before = Read-JourneyState
+    Send-JourneyKey 'g'
+    Wait-JourneyState 'preview menu opened for palette selection' {
+        param($s) $s.screen -eq 'ArchitectMenuScreen'
+    } | Out-Null
+    Send-JourneyKey 'c'
+    $picker = Wait-JourneyState 'palette picker exposed a real clickable palette target' {
+        param($s)
+        $s.screen -eq 'PalettePickerScreen' -and $null -ne $s.paletteTargetX
+    }
+
+    $origin = Get-JourneyWindowOrigin -WindowId $WindowId
+    $targetX = $origin.X + [int][Math]::Round([double]$picker.paletteTargetX)
+    $targetY = $origin.Y + [int][Math]::Round([double]$picker.paletteTargetY)
+    Invoke-Xdotool -Arguments @('mousemove', '--sync', "$targetX", "$targetY")
+    Invoke-Xdotool -Arguments @('click', '1')
+    Wait-JourneyState 'palette click changed the active palette' {
+        param($s)
+        $s.screen -eq 'PalettePickerScreen' -and $s.paletteName -eq $picker.paletteTargetName
+    } | Out-Null
+    Send-JourneyKey 'Escape'
+    Wait-JourneyState 'palette picker closed back to preview' {
+        param($s) $s.phase -eq 'Previewing' -and -not $s.screen
+    } | Out-Null
+    Add-JourneyCheck 'real pointer movement and click changed the preview palette'
+}
+
+function Save-JourneyBuild {
+    Send-JourneyKey 'g'
+    Wait-JourneyState 'preview menu opened for save' { param($s) $s.screen -eq 'ArchitectMenuScreen' } | Out-Null
+    Send-JourneyKey 's'
+    Wait-JourneyState 'save-name prompt opened' { param($s) $s.screen -eq 'TextInputPromptScreen' } | Out-Null
+    Send-JourneyText 'e2e_journey'
+    Send-JourneyKey 'Return'
+    Wait-JourneyState 'save completed and architect unloaded' {
+        param($s) $s.phase -eq 'Empty' -and -not $s.screen
+    } | Out-Null
+
+    $saved = Join-Path (Join-Path $runDirectory 'schematics') 'e2e_journey.nbt'
+    $deadline = (Get-Date).AddSeconds(30)
+    while ((Get-Date) -lt $deadline -and -not (Test-Path $saved)) {
+        Start-Sleep -Milliseconds 250
+    }
+    if (-not (Test-Path $saved) -or (Get-Item $saved).Length -le 0) {
+        throw "Saved schematic was not created: $saved"
+    }
+    Add-JourneyCheck 'real text entry and Enter saved a non-empty schematic file'
+}
+
+function Print-JourneyBuild {
+    Send-JourneyKey 'g'
+    Wait-JourneyState 'preview menu opened for print' { param($s) $s.screen -eq 'ArchitectMenuScreen' } | Out-Null
+    Send-JourneyKey 'p'
+    Wait-JourneyState 'vanilla-server command fallback started' {
+        param($s) $s.phase -eq 'PrintingToMultiplayer'
+    } | Out-Null
+    Wait-JourneyState 'printed blocks match the preview in the server world' {
+        param($s)
+        $s.phase -eq 'Empty' -and [bool]$s.printedWorldMatches -and
+            [int]$s.expectedPrintedBlocks -gt 0
+    } -Seconds 240 | Out-Null
+    Add-JourneyCheck 'real menu input printed the second build through the vanilla command fallback'
+}
+
+function Write-JourneyResult {
+    param(
+        [string]$Status,
+        [string]$ErrorMessage
+    )
+
+    $state = Read-JourneyState
+    $result = [ordered]@{
+        status = $Status
+        version = $Version
+        loader = $Loader
+        checks = @($checks)
+        durationSeconds = [Math]::Round(((Get-Date) - $timelineStart).TotalSeconds, 3)
+        finalState = $state
+    }
+    if ($ErrorMessage) {
+        $result['error'] = $ErrorMessage
+    }
+    $result | ConvertTo-Json -Depth 10 | Set-Content $resultPath -Encoding utf8
+
+    @(
+        '# Recorded player journey'
+        ''
+        "| Field | Value |"
+        "| --- | --- |"
+        "| Target | Minecraft $Version / $Loader |"
+        "| Status | **$Status** |"
+        "| Checks | $($checks.Count) |"
+        "| Duration | $([Math]::Round($result.durationSeconds, 1)) seconds |"
+        "| Recording | ``journey.mp4`` in the uploaded artifact |"
+        ''
+        '## Checks'
+        ''
+        $(if ($checks.Count) { $checks | ForEach-Object { "- [x] $_" } } else { '- [ ] No journey check completed.' })
+        $(if ($ErrorMessage) { '', '## Failure', '', "``$ErrorMessage``" })
+    ) | Set-Content (Join-Path $resultDirectory 'summary.md') -Encoding utf8
+}
+
+try {
+    Add-JourneyTimeline 'Starting vanilla fixture server'
+    $server = Start-TestVanillaServer -NodeId "$Version-$Loader-$Port" -Properties $properties `
+        -RuntimeRoot $serverRuntimeRoot -Port $Port -Motd 'Mighty Architect Player Journey' `
+        -OfflineOperator 'ArchitectTest' -Creative
+
+    $recorderArguments = @(
+        '-y', '-nostdin', '-loglevel', 'warning',
+        '-f', 'x11grab', '-draw_mouse', '1', '-framerate', '20',
+        '-video_size', '1280x720', '-i', "$($env:DISPLAY).0+0,0",
+        '-an', '-c:v', 'libx264', '-preset', 'ultrafast', '-crf', '28',
+        '-pix_fmt', 'yuv420p', '-movflags', '+faststart', '-t', "$TimeoutSeconds",
+        $videoPath
+    )
+    $recorder = Start-Process -FilePath 'ffmpeg' -ArgumentList $recorderArguments `
+        -RedirectStandardError $ffmpegLog -PassThru
+    Start-Sleep -Seconds 1
+    if ($recorder.HasExited) {
+        $tail = if (Test-Path $ffmpegLog) { (Get-Content $ffmpegLog -Tail 30) -join "`n" } else { '' }
+        throw "FFmpeg exited before the client launched (code $($recorder.ExitCode))`n$tail"
+    }
+    Add-JourneyTimeline 'FFmpeg recording started'
+
+    $env:MIGHTYARCHITECT_PLAYER_JOURNEY_SERVER = "127.0.0.1:$Port"
+    $gradleArguments = @(
+        ":${Loader}:${Version}:runProductionPlayerJourney",
+        '--console=plain',
+        '--no-daemon',
+        '-Porg.gradle.java.installations.fromEnv=JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64'
+    )
+    $clientProcess = Start-Process -FilePath $gradle -ArgumentList $gradleArguments `
+        -WorkingDirectory $repoRoot -RedirectStandardOutput $gradleStdout `
+        -RedirectStandardError $gradleStderr -PassThru
+
+    $windowId = Focus-JourneyWindow
+    Wait-JourneyState 'packaged client joined the fixture world' {
+        param($s) [bool]$s.worldReady -and -not [bool]$s.overlayVisible -and -not $s.screen
+    } -Seconds 240 | Out-Null
+    Add-JourneyCheck 'packaged production client launched, focused, and joined a vanilla server'
+
+    Send-JourneyCommand '/fill -8 3 -8 8 3 8 minecraft:stone'
+    Aim-JourneyAt -X 0 -Z 0
+    Add-JourneyCheck 'real chat input prepared a deterministic world fixture'
+
+    $beforeIdleScroll = Read-JourneyState
+    Invoke-Xdotool -Arguments @('click', '5')
+    $afterIdleScroll = Wait-JourneyState 'idle wheel input cycled the vanilla hotbar' {
+        param($s)
+        [int]$s.scrollEvents -gt [int]$beforeIdleScroll.scrollEvents -and
+            [int]$s.selectedHotbarSlot -ne [int]$beforeIdleScroll.selectedHotbarSlot
+    }
+    Add-JourneyCheck "idle scroll changed hotbar slot $($beforeIdleScroll.selectedHotbarSlot) -> $($afterIdleScroll.selectedHotbarSlot)"
+
+    Start-JourneyComposition
+    Select-JourneyPalette -WindowId $windowId
+    Send-JourneyKey 'F2'
+    Save-JourneyBuild
+
+    Start-JourneyComposition
+    Send-JourneyKey 'F2'
+    Print-JourneyBuild
+    Send-JourneyKey 'F2'
+
+    Add-JourneyCheck 'packaged client remained responsive through both complete journeys'
+    Write-JourneyResult -Status 'passed' -ErrorMessage ''
+} catch {
+    $failure = $_
+    Add-JourneyTimeline "FAIL: $($_.Exception.Message)"
+    Write-JourneyResult -Status 'failed' -ErrorMessage $_.Exception.Message
+} finally {
+    Remove-Item Env:MIGHTYARCHITECT_PLAYER_JOURNEY_SERVER -ErrorAction SilentlyContinue
+
+    if ($clientProcess) {
+        Stop-TestProcessTree -Process $clientProcess
+    }
+    if ($server) {
+        Stop-TestProcessTree -Process $server.Process
+        if (Test-Path $server.Log) {
+            Copy-Item $server.Log (Join-Path $resultDirectory 'server.log') -Force
+        }
+    }
+    if ($recorder -and -not $recorder.HasExited) {
+        & /bin/kill -INT $recorder.Id
+        if (-not $recorder.WaitForExit(30000)) {
+            Stop-TestProcessTree -Process $recorder
+        }
+    }
+
+    if (Test-Path $videoPath) {
+        & ffmpeg -y -loglevel error -i $videoPath `
+            -vf 'fps=1/12,scale=320:-1,tile=4x4' -frames:v 1 $contactSheetPath
+    }
+    $screenshots = Join-Path $runDirectory 'screenshots'
+    if (Test-Path $screenshots) {
+        Copy-Item $screenshots (Join-Path $resultDirectory 'screenshots') -Recurse -Force
+    }
+}
+
+if (-not $failure -and (-not (Test-Path $videoPath) -or (Get-Item $videoPath).Length -le 0)) {
+    $failure = [InvalidOperationException]::new('The journey passed but its MP4 recording was not produced.')
+    Add-JourneyTimeline "FAIL: $($failure.Message)"
+    Write-JourneyResult -Status 'failed' -ErrorMessage $failure.Message
+}
+
+if ($failure) {
+    throw $failure
+}
+
+Write-Host "Recorded player journey passed. Evidence: $resultDirectory"

--- a/scripts/run-player-journey.ps1
+++ b/scripts/run-player-journey.ps1
@@ -299,12 +299,12 @@ function Print-JourneyBuild {
     Wait-JourneyState 'vanilla-server command fallback started' {
         param($s) $s.phase -eq 'PrintingToMultiplayer'
     } | Out-Null
-    Wait-JourneyState 'printed blocks match the preview in the server world' {
+    $printed = Wait-JourneyState 'printed block identities match the preview in the server world' {
         param($s)
-        $s.phase -eq 'Empty' -and [bool]$s.printedWorldMatches -and
+        $s.phase -eq 'Empty' -and [bool]$s.printedWorldBlockTypesMatch -and
             [int]$s.expectedPrintedBlocks -gt 0
-    } -Seconds 240 | Out-Null
-    Add-JourneyCheck 'real menu input printed the second build through the vanilla command fallback'
+    } -Seconds 240
+    Add-JourneyCheck "real menu input printed all $($printed.expectedPrintedBlocks) block identities through the vanilla command fallback ($($printed.matchingPrintedBlocks) exact settled states)"
 }
 
 function Write-JourneyResult {

--- a/scripts/run-player-journey.ps1
+++ b/scripts/run-player-journey.ps1
@@ -293,6 +293,7 @@ function Save-JourneyBuild {
 }
 
 function Print-JourneyBuild {
+    Aim-JourneyAt -X 7 -Z 7
     Send-JourneyKey 'g'
     Wait-JourneyState 'preview menu opened for print' { param($s) $s.screen -eq 'ArchitectMenuScreen' } | Out-Null
     Send-JourneyKey 'p'


### PR DESCRIPTION
## Summary
- add an advisory 1.20.2 Fabric player-journey workflow that records the packaged client under Xvfb
- drive keyboard, mouse-button, pointer, text, and wheel input externally through xdotool/XTEST
- exercise a real Medieval theme -> two-corner room -> extra floor -> preview -> palette -> save journey, then repeat and print through the vanilla-server command fallback
- upload MP4, contact sheet, screenshots, timeline, observer state, result JSON, and client/server/FFmpeg logs for review
- keep the test companion passive after its setup connection; it observes production input hooks and game state but does not invoke architect actions

## Validation
- `:fabric:1.20.2:buildClientTestMod :fabric:1.20.2:test`
- `:forge:1.19.4:buildClientTestMod :neoforge:1.21.1:buildClientTestMod :fabric:26.2:buildClientTestMod`
- `scripts/check-source-shape.ps1`
- PowerShell parser and deterministic offline-operator fixture checks

The new workflow is separate from the required `All versions green` check. This PR should not be merged until the uploaded recording and structured result have been reviewed.