### PR TITLE
Release prep: verified version ranges, CHANGELOG.md, and a dry-run-gated publishing pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: Build (all versions)
 
-on: [push, pull_request]
+on:
+  # Every branch, but not tags: a version tag is built once, by release.yml calling this workflow,
+  # so the same commit is not put through the matrix twice. Branch pushes still run on their own,
+  # which is what lets a throwaway branch serve as a mutation test without opening a PR.
+  push:
+    branches: ['**']
+  pull_request:
+  workflow_call:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,8 @@ name: Release
 #                        the live step into a manual gate with the dry-run artifacts already in hand.
 #
 # Two things refuse to publish live: a tag that does not match mod_version in gradle.properties, and a
-# CHANGELOG.md whose top section is still [Unreleased] (checked by checkPublishMetadata).
+# CHANGELOG.md whose top heading is still marked unreleased or does not name mod_version (checked by
+# checkPublishMetadata).
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,177 @@
+name: Release
+
+# Publishes the 25 jars to the configured hosting platforms.
+#
+#   workflow_dispatch  - dry run on any ref: the full matrix must pass, then every node writes what it
+#                        WOULD upload (jar + resolved listing metadata) into a review artifact, and a
+#                        table of all 25 publications lands in the run summary. Nothing is uploaded.
+#   push of a v* tag   - the same, then the live upload - from the `release` environment, so that
+#                        MODRINTH_TOKEN / CURSEFORGE_TOKEN live there rather than as repository secrets
+#                        a PR build could see, and so a required reviewer on that environment turns
+#                        the live step into a manual gate with the dry-run artifacts already in hand.
+#
+# Two things refuse to publish live: a tag that does not match mod_version in gradle.properties, and a
+# CHANGELOG.md whose top section is still [Unreleased] (checked by checkPublishMetadata).
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  # The full matrix - builds, metadata verification, JUnit, dedicated server, both client lanes and
+  # the source-shape gate - on exactly the commit being released.
+  verify:
+    name: Verify
+    uses: ./.github/workflows/build.yml
+
+  tag-matches-version:
+    name: Tag matches mod_version
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          set -euo pipefail
+          declared=$(grep -E '^mod_version=' gradle.properties | cut -d= -f2- | tr -d '\r')
+          tagged="${GITHUB_REF_NAME#v}"
+          if [ "$declared" != "$tagged" ]; then
+            echo "::error::tag v$tagged does not match mod_version=$declared in gradle.properties"
+            exit 1
+          fi
+          echo "Releasing $declared"
+
+  dry-run:
+    name: Dry run ${{ matrix.mc }}
+    needs: verify
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Keep in step with build.yml: one job per Minecraft version, every loader it targets.
+        include:
+          - { mc: "1.19.4",  loader2: forge }
+          - { mc: "1.20.1",  loader2: forge }
+          - { mc: "1.20.2",  loader2: "" }
+          - { mc: "1.20.4",  loader2: neoforge }
+          - { mc: "1.20.6",  loader2: neoforge }
+          - { mc: "1.21.1",  loader2: neoforge }
+          - { mc: "1.21.4",  loader2: neoforge }
+          - { mc: "1.21.6",  loader2: neoforge }
+          - { mc: "1.21.8",  loader2: neoforge }
+          - { mc: "1.21.10", loader2: neoforge }
+          - { mc: "1.21.11", loader2: neoforge }
+          - { mc: "26.1",    loader2: neoforge }
+          - { mc: "26.2",    loader2: neoforge }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: |
+            17
+            21
+            25
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Dry-run publish ${{ matrix.mc }}
+        env:
+          JDKS: JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64
+        run: |
+          chmod +x ./gradlew
+          tasks=":fabric:${{ matrix.mc }}:publishMods"
+          if [ -n "${{ matrix.loader2 }}" ]; then
+            tasks="$tasks :${{ matrix.loader2 }}:${{ matrix.mc }}:publishMods"
+          fi
+          ./gradlew $tasks -Porg.gradle.java.installations.fromEnv=$JDKS --stacktrace
+
+      - name: Summarize what would be uploaded
+        run: |
+          set -euo pipefail
+          {
+            echo "### ${{ matrix.mc }}"
+            echo
+            echo "| loader | file | version | channel | game versions | jar range | loaders |"
+            echo "| --- | --- | --- | --- | --- | --- | --- |"
+            for f in */versions/${{ matrix.mc }}/build/publishMods/metadata-*.json; do
+              jq -r '"| \(.loader) | `\(.file)` | `\(.versionNumber)` | \(.channel) | \(.gameVersions | join(", ")) | `\(.jarRange)` | \(.loaders | join(", ")) |"' "$f"
+            done
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: publish-dry-run-${{ matrix.mc }}
+          if-no-files-found: error
+          path: |
+            fabric/versions/${{ matrix.mc }}/build/publishMods/
+            forge/versions/${{ matrix.mc }}/build/publishMods/
+            neoforge/versions/${{ matrix.mc }}/build/publishMods/
+
+  publish:
+    name: Publish ${{ matrix.mc }}
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [verify, tag-matches-version, dry-run]
+    runs-on: ubuntu-latest
+    environment: release
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include:
+          - { mc: "1.19.4",  loader2: forge }
+          - { mc: "1.20.1",  loader2: forge }
+          - { mc: "1.20.2",  loader2: "" }
+          - { mc: "1.20.4",  loader2: neoforge }
+          - { mc: "1.20.6",  loader2: neoforge }
+          - { mc: "1.21.1",  loader2: neoforge }
+          - { mc: "1.21.4",  loader2: neoforge }
+          - { mc: "1.21.6",  loader2: neoforge }
+          - { mc: "1.21.8",  loader2: neoforge }
+          - { mc: "1.21.10", loader2: neoforge }
+          - { mc: "1.21.11", loader2: neoforge }
+          - { mc: "26.1",    loader2: neoforge }
+          - { mc: "26.2",    loader2: neoforge }
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: |
+            17
+            21
+            25
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Publish ${{ matrix.mc }}
+        env:
+          JDKS: JAVA_HOME_17_X64,JAVA_HOME_21_X64,JAVA_HOME_25_X64
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+        run: |
+          chmod +x ./gradlew
+          tasks=":fabric:${{ matrix.mc }}:publishMods"
+          if [ -n "${{ matrix.loader2 }}" ]; then
+            tasks="$tasks :${{ matrix.loader2 }}:${{ matrix.mc }}:publishMods"
+          fi
+          ./gradlew $tasks -PpublishLive=true -Porg.gradle.java.installations.fromEnv=$JDKS --stacktrace
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: publish-result-${{ matrix.mc }}
+          if-no-files-found: warn
+          path: |
+            fabric/versions/${{ matrix.mc }}/build/publishMods/*.json
+            forge/versions/${{ matrix.mc }}/build/publishMods/*.json
+            neoforge/versions/${{ matrix.mc }}/build/publishMods/*.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,9 @@ name: Release
 
 # Publishes the 25 jars to the configured hosting platforms.
 #
+#   pull_request       - only when publishing-related files change: the dry run alone (the PR's own
+#                        build.yml run already verifies the same commit). Keeps the pipeline exercised
+#                        between releases instead of discovering breakage on release day.
 #   workflow_dispatch  - dry run on any ref: the full matrix must pass, then every node writes what it
 #                        WOULD upload (jar + resolved listing metadata) into a review artifact, and a
 #                        table of all 25 publications lands in the run summary. Nothing is uploaded.
@@ -17,6 +20,15 @@ on:
   push:
     tags: ['v*']
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/release.yml'
+      - 'buildSrc/**'
+      - 'CHANGELOG.md'
+      - 'gradle.properties'
+      - 'stonecutter.gradle'
+      - '*/build.gradle'
+      - 'versions/*/gradle.properties'
 
 concurrency:
   group: publish-${{ github.ref }}
@@ -27,9 +39,11 @@ permissions:
 
 jobs:
   # The full matrix - builds, metadata verification, JUnit, dedicated server, both client lanes and
-  # the source-shape gate - on exactly the commit being released.
+  # the source-shape gate - on exactly the commit being released. A pull request already gets this
+  # from build.yml on the same commit, so it is not repeated there.
   verify:
     name: Verify
+    if: github.event_name != 'pull_request'
     uses: ./.github/workflows/build.yml
 
   tag-matches-version:
@@ -51,6 +65,8 @@ jobs:
   dry-run:
     name: Dry run ${{ matrix.mc }}
     needs: verify
+    # Runs after a successful verify, or directly on a pull request where verify is skipped.
+    if: ${{ !cancelled() && (needs.verify.result == 'success' || needs.verify.result == 'skipped') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,21 @@ All notable changes to The Mighty Architectury. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). One entry covers every Minecraft version
 the release ships for; version-specific notes say which versions they apply to.
 
-## [Unreleased]
+## [2.0.0] — unreleased
 
-<!-- DECISIONS STILL OPEN — resolve before this file is fed to Modrinth/CurseForge:
-     1. Version number and channel: the heading above becomes the chosen version, e.g. [2.0.0].
-     2. 1.19.2 / 1.19.3: the "Removed" entry below assumes they are end-of-life. If a 1.19.2 build
-        is added instead, delete that entry and list 1.19.2 under "Added". -->
+<!-- DECISION STILL OPEN — resolve before tagging v2.0.0:
+     1.19.2 / 1.19.3: the "Removed" entry below assumes they are end-of-life. If a 1.19.2 build
+     is added instead, delete that entry and list 1.19.2 under "Added".
+     Replace "unreleased" above with the release date when tagging. -->
 
 This release supersedes every previously published jar from 0.8.0 (1.19.4) through 0.11.0 (1.21.11)
 and is the first built from the single-branch, multi-version codebase. It ships for 13 Minecraft
 versions — 1.19.4, 1.20.1, 1.20.2, 1.20.4, 1.20.6, 1.21.1, 1.21.4, 1.21.6, 1.21.8, 1.21.10, 1.21.11,
 26.1 and 26.2 — on Fabric everywhere, NeoForge from 1.20.4, and Forge on 1.19.4 and 1.20.1. 1.20.2
 is Fabric-only: no NeoForge 20.2 build was ever published with the metadata the toolchain needs.
-Architectury API is no longer required; Fabric builds still need Fabric API.
+Architectury API is no longer required; Fabric builds still need Fabric API. Versions that had a
+published 0.x build ship as full releases; the six Minecraft versions that have never had a build
+(1.20.2, 1.20.4, 1.20.6, 1.21.8, 26.1, 26.2) ship as betas until they have users behind them.
 
 ### Security — update now if you run a server with the mod installed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,123 @@
+# Changelog
+
+All notable changes to The Mighty Architectury. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). One entry covers every Minecraft version
+the release ships for; version-specific notes say which versions they apply to.
+
+## [Unreleased]
+
+<!-- DECISIONS STILL OPEN — resolve before this file is fed to Modrinth/CurseForge:
+     1. Version number and channel: the heading above becomes the chosen version, e.g. [2.0.0].
+     2. 1.19.2 / 1.19.3: the "Removed" entry below assumes they are end-of-life. If a 1.19.2 build
+        is added instead, delete that entry and list 1.19.2 under "Added". -->
+
+This release supersedes every previously published jar from 0.8.0 (1.19.4) through 0.11.0 (1.21.11)
+and is the first built from the single-branch, multi-version codebase. It ships for 13 Minecraft
+versions — 1.19.4, 1.20.1, 1.20.2, 1.20.4, 1.20.6, 1.21.1, 1.21.4, 1.21.6, 1.21.8, 1.21.10, 1.21.11,
+26.1 and 26.2 — on Fabric everywhere, NeoForge from 1.20.4, and Forge on 1.19.4 and 1.20.1. 1.20.2
+is Fabric-only: no NeoForge 20.2 build was ever published with the metadata the toolchain needs.
+Architectury API is no longer required; Fabric builds still need Fabric API.
+
+### Security — update now if you run a server with the mod installed
+
+- **Serverbound packets are now authorized.** Every earlier version let any client carrying the
+  mod rewrite loaded chunks and place signs anywhere on any server that also had it — no gamemode,
+  permission, distance or size check. Building now requires creative mode or permission level 2,
+  and every placement is checked against world bounds, loaded chunks, a 256-block reach, the world
+  border, spawn protection and claim mods (`Level#mayInteract`), and a per-player placement budget.
+  Packet sizes are validated before anything is allocated.
+  ([#35](https://github.com/TimStewartJ/TheMightyArchitectury/pull/35))
+- Multiplayer printing no longer changes `sendCommandFeedback` or `logAdminCommands`. Earlier
+  versions turned both off while printing and only restored them if the print finished, so a
+  crash or disconnect mid-print left the server without admin-command logging. **The update does
+  not repair that automatically**: if a server ever ran an older version, check
+  `/gamerule logAdminCommands`.
+- Saving themes, palettes, designs and schematics is atomic. A crash during a save no longer
+  destroys the file being written.
+
+### Fixed
+
+- Exported designs named from a sign are no longer saved as `SignText@…` on 1.20 and newer.
+  Sign naming works again and re-exporting a design overwrites it instead of leaving an orphan.
+  ([#38](https://github.com/TimStewartJ/TheMightyArchitectury/pull/38))
+- Extending a built-in theme with your own designs no longer deletes the built-in designs in the
+  same layer.
+- Editing one theme's palette no longer changes the default palette for every other theme.
+- Palettes and themes load outside a world; the title screen no longer crashes on them.
+- One malformed palette file, or one unknown theme enum value, no longer prevents every other
+  palette or theme from loading. Failures are logged and skipped.
+- Exporting a theme no longer fails silently when its export folder is missing.
+- Theme and design names are sanitized before they become file names (path separators, `..`,
+  reserved Windows device names).
+- The composer's layout HUD is visible again on 1.21.1 and 1.21.4
+  ([#26](https://github.com/TimStewartJ/TheMightyArchitectury/issues/26)).
+- Opening the palette picker on NeoForge no longer crashes with `IllegalAccessError`
+  ([#27](https://github.com/TimStewartJ/TheMightyArchitectury/issues/27)).
+- The composer HUD renders on 1.21.6, 1.21.8, 1.21.10 and 1.21.11.
+- Item model definitions are included on 1.21.4 and 1.21.6, where items need them to render.
+- Palette previews render from 1.21.6 onward.
+- World-space measurement labels are drawn on a backdrop their text contrasts with, on every
+  version ([#34](https://github.com/TimStewartJ/TheMightyArchitectury/pull/34)).
+- The theme-settings screen's name and author fields can be typed into, and resizing the window
+  no longer duplicates its widgets ([#36](https://github.com/TimStewartJ/TheMightyArchitectury/pull/36)).
+- The tool bar no longer leaks its tint into whatever vanilla draws next.
+- Resource-pack formats are correct on 1.21.4, 1.21.10 and 1.21.11 (the jars claimed the wrong
+  `pack_format`).
+- Each jar now declares a bounded Minecraft range instead of an open-ended one, so installing a
+  jar on a version it was not built for is refused by the loader instead of crashing in game. The
+  1.21.1, 1.21.4, 1.21.6 and 1.21.8 jars no longer claim 1.21.2–1.21.3, 1.21.5, 1.21.7 or 1.21.9,
+  where they would fail (renamed or removed render, registry and input APIs, and a NeoForge
+  packet-sender move during its 21.7 line).
+- Large builds no longer stall the client when you change palettes or re-roll. The work is spread
+  across ticks and the previous preview stays visible until the replacement is ready
+  ([#42](https://github.com/TimStewartJ/TheMightyArchitectury/pull/42)).
+- Preview textures no longer go stale after a resource reload (F3+T).
+- The same sketch now materializes identically every time; block randomization is seeded.
+
+### Changed
+
+- **Your themes and palettes now live in `<game directory>/mightyarchitect/`** instead of three
+  generic folders in the instance root ([#41](https://github.com/TimStewartJ/TheMightyArchitectury/pull/41)).
+  On first launch the mod *copies* `themes/` and `palettes/` there; the originals are left exactly
+  where they were and are still read, so nothing is lost if something goes wrong. `schematics/` is
+  deliberately not moved — it is shared with Create. Note that files you create *after* updating
+  are written only to the new location, so going back to an older version will not see them.
+- Theme, palette and design files are read and written with proper codecs instead of
+  string round-tripping. Every existing file still loads; new files carry a `DataVersion`.
+- Multiplayer printing on a server that has the mod now uses the mod's own packets whenever the
+  connection advertises them, so it no longer spams command feedback or loses blocks to command
+  limits ([#43](https://github.com/TimStewartJ/TheMightyArchitectury/pull/43)).
+- On a vanilla or mod-less server, printing still falls back to commands, but more safely: block
+  states are serialized the way `/setblock` expects, short runs are batched into bounded `/fill`
+  commands, at most one command is sent per tick, and each batch is re-planned against the current
+  world right before it is sent. Blocks that already match are left untouched.
+- Palette names sort naturally in the picker (`p2` before `p10`).
+- The mod list shows the mod's icon and links to Modrinth and the issue tracker on every loader.
+
+### Added
+
+- Support for Minecraft 1.20.2, 1.20.4, 1.20.6, 1.21.8, 26.1 and 26.2.
+- **Resource packs can ship complete themes.** Put a theme under
+  `assets/mightyarchitect/themes/<name>/theme.json` and it appears in the theme list; packs can also
+  override the built-in themes and palettes, and F3+T reloads them. `theme.json` gained an optional
+  `HeightSequence` so a pack-provided theme can define its own floor heights.
+
+### Removed
+
+- Support for Minecraft 1.19.2 and 1.19.3. The last builds for those versions (0.6.2 and 0.7.0)
+  predate the server-side authorization fix above and will not be updated.
+- The Architectury API dependency.
+
+### Internal
+
+No player-visible change relative to the last published jars; listed because they change how the
+jars are built and verified.
+
+- Every jar is now built from one source tree with [Stonecutter](https://stonecutter.kikugie.dev/)
+  and each loader's own toolchain (Fabric Loom, ModDevGradle); there are no per-version branches.
+- Every release build runs a JUnit suite, a dedicated-server print test and a client test against
+  both the development classpath and the packaged jar, on all 25 targets.
+- The blueprint post-effect is reached through an accessor mixin rather than reflection that
+  matched a vanilla method by shape, and the legacy-Forge mixin configs name their refmap
+  ([#36](https://github.com/TimStewartJ/TheMightyArchitectury/pull/36),
+  [#37](https://github.com/TimStewartJ/TheMightyArchitectury/pull/37)).

--- a/README.md
+++ b/README.md
@@ -153,3 +153,30 @@ To stop every retained session:
 ```powershell
 pwsh -File scripts/stop-kept-open-clients.ps1 -All
 ```
+
+## Releasing
+
+Publishing goes through [mod-publish-plugin](https://github.com/modmuss50/mod-publish-plugin),
+applied to every loader node by `buildSrc/src/main/groovy/mightyarchitect.publish.gradle`. Each
+node's listing metadata lives next to its toolchain values in `versions/<mc>/gradle.properties`:
+
+| property | meaning |
+| --- | --- |
+| `meta_game_versions` | the **inclusive** list of Minecraft versions the listing declares. Written out explicitly because `meta_mc_max` is *exclusive*; `checkPublishMetadata` (part of `check`, so part of every CI build) fails if any listed version falls outside the jar's own `[meta_mc_range, meta_mc_max)` |
+| `meta_release_channel` | `release`, `beta` or `alpha` for that node's uploads |
+
+Release notes are the top section of `CHANGELOG.md`. The version number of each upload is the
+jar's own version plus a loader suffix (`2.0.0+mc1.21.1-fabric`), one upload per jar, as before.
+
+```powershell
+./gradlew :fabric:1.21.1:publishMods   # dry run: writes build/publishMods/ for review, uploads nothing
+./gradlew publishAll                   # the same for all 25 jars
+./gradlew publishAll -PpublishLive=true # real upload; needs MODRINTH_TOKEN (and CURSEFORGE_TOKEN)
+```
+
+In CI, `.github/workflows/release.yml` runs the whole matrix on the commit, then a dry run of all 25
+publications whose resolved metadata is tabulated in the run summary (`workflow_dispatch` on any
+ref stops here). Pushing a `v<mod_version>` tag continues to the live upload from the `release`
+environment, which is where the tokens belong and where a required reviewer makes the upload a
+manual gate. A tag that does not match `mod_version`, or a `CHANGELOG.md` still headed
+`[Unreleased]`, refuses to publish.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,17 @@
 
 # The Mighty Architectury
 
-A WIP port of [simibubi's](https://github.com/simibubi) [The Mighty Architect](https://github.com/simibubi/TheMightyArchitect)
-to Fabric and NeoForge. No third-party multiloader framework: each loader is built with its own
-official toolkit, so the mod has no runtime dependencies beyond the loader itself (plus Fabric API
-on Fabric).
+A port of [simibubi's](https://github.com/simibubi) [The Mighty Architect](https://github.com/simibubi/TheMightyArchitect)
+to Fabric, NeoForge and Forge, maintained for 13 Minecraft versions from 1.19.4 to 26.2. No
+third-party multiloader framework: each loader is built with its own official toolkit, so the mod
+has no runtime dependencies beyond the loader itself (plus Fabric API on Fabric). Downloads are on
+[Modrinth](https://modrinth.com/mod/the-mighty-architectury); what changed in each release is in
+[`CHANGELOG.md`](CHANGELOG.md).
 
-This is experimental. Some things may still be broken!
+Every jar is verified the way it ships: the same client test harness runs against the packaged
+artifact on all 25 targets, alongside a dedicated-server test and a JUnit suite, on every change.
+Bugs still happen — please [report them](https://github.com/TimStewartJ/TheMightyArchitectury/issues)
+with the Minecraft version and loader.
 
 ## Contributing
 
@@ -178,5 +183,5 @@ In CI, `.github/workflows/release.yml` runs the whole matrix on the commit, then
 publications whose resolved metadata is tabulated in the run summary (`workflow_dispatch` on any
 ref stops here). Pushing a `v<mod_version>` tag continues to the live upload from the `release`
 environment, which is where the tokens belong and where a required reviewer makes the upload a
-manual gate. A tag that does not match `mod_version`, or a `CHANGELOG.md` still headed
-`[Unreleased]`, refuses to publish.
+manual gate. A tag that does not match `mod_version`, or a `CHANGELOG.md` whose top heading is
+still marked unreleased or does not name `mod_version`, refuses to publish.

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -24,4 +24,7 @@ dependencies {
     // ModDevGradle's legacy addon, released in lockstep with the main plugin. It is what builds
     // the 1.19.4 / 1.20.1 Forge targets, where NeoForge does not exist yet.
     implementation "net.neoforged.moddev.legacyforge:net.neoforged.moddev.legacyforge.gradle.plugin:${rootProps.moddev_version}"
+    // Publishes the finished jars to Modrinth / CurseForge. Same shared-classloader argument: one
+    // copy of the plugin serves all 25 loader nodes.
+    implementation "me.modmuss50.mod-publish-plugin:me.modmuss50.mod-publish-plugin.gradle.plugin:${rootProps.mod_publish_plugin_version}"
 }

--- a/buildSrc/src/main/groovy/mightyarchitect.publish.gradle
+++ b/buildSrc/src/main/groovy/mightyarchitect.publish.gradle
@@ -1,0 +1,182 @@
+// Release publishing for one loader node: Modrinth now, CurseForge once a project exists (#13).
+//
+// Applied by the three branch scripts after they have set two project properties:
+//   ext.publishArtifactTask - name of the task whose archive is the distributable jar
+//                             (remapJar / jar on Fabric, jar on NeoForge, reobfJar on Forge)
+//   ext.publishLoaders      - the loader tags the listing carries, e.g. ["fabric"]
+//
+// Everything node-specific comes from versions/<mc>/gradle.properties:
+//   meta_game_versions    - comma-separated Minecraft versions the LISTING declares. Explicit on
+//                           purpose: meta_mc_max is exclusive while every hosting platform takes an
+//                           inclusive list, and deriving one from the other is exactly how a jar ends
+//                           up listed for a version it was never run on. checkPublishMetadata proves
+//                           every listed version sits inside the jar's own [meta_mc_range, meta_mc_max).
+//   meta_release_channel  - release | beta | alpha (defaults to beta, the channel every previously
+//                           published version used)
+//
+// Nothing here can upload by accident: publishMods is a dry run unless -PpublishLive=true is passed,
+// and a live run additionally refuses a CHANGELOG.md whose top section is still [Unreleased].
+import me.modmuss50.mpp.ReleaseType
+import me.modmuss50.mpp.platforms.modrinth.ModrinthEnvironment
+import org.gradle.api.tasks.bundling.AbstractArchiveTask
+
+plugins {
+    id "me.modmuss50.mod-publish-plugin"
+}
+
+def node = rootProject.project(":${stonecutter.current.version}")
+String mcVersion = node.property('minecraft_version').toString()
+List<String> loaders = (project.publishLoaders as List<String>)
+String primaryLoader = loaders[0]
+boolean live = project.findProperty("publishLive") == "true"
+String channel = (node.findProperty('meta_release_channel') ?: 'beta').toString().toLowerCase()
+List<String> gameVersions = node.property('meta_game_versions').toString()
+    .split(',').collect { it.trim() }.findAll { !it.isEmpty() }
+String mcMin = node.property('meta_mc_range').toString()
+String mcMax = node.property('meta_mc_max').toString()
+String javaRange = node.property('meta_java_range').toString()
+File changelogFile = rootProject.file("CHANGELOG.md")
+String modrinthProjectId = rootProject.property('modrinth_project_id').toString().trim()
+String curseforgeProjectId = (rootProject.findProperty('curseforge_project_id') ?: '').toString().trim()
+String curseforgeProjectSlug = (rootProject.findProperty('curseforge_project_slug') ?: '').toString().trim()
+String versionNumber = "${project.version}-${primaryLoader}".toString()
+String displayTitle = "The Mighty Architectury ${rootProject.mod_version} for ${primaryLoader} ${mcVersion}".toString()
+
+// Numeric dotted comparison - the only shape Minecraft release ids take (1.20 < 1.20.1 < 26.1).
+def compareMc = { String a, String b ->
+    List<Integer> pa = a.tokenize('.').collect { it as int }
+    List<Integer> pb = b.tokenize('.').collect { it as int }
+    for (int i = 0; i < Math.max(pa.size(), pb.size()); i++) {
+        int x = i < pa.size() ? pa[i] : 0
+        int y = i < pb.size() ? pb[i] : 0
+        if (x != y) return x <=> y
+    }
+    return 0
+}
+
+// The top section of CHANGELOG.md: from the first "## " heading up to the next one, HTML comments
+// removed. That section becomes the release notes on every platform.
+def topChangelogSection = {
+    if (!changelogFile.exists()) {
+        throw new GradleException("${changelogFile} does not exist; the release notes come from its top section")
+    }
+    List<String> lines = changelogFile.readLines()
+    int start = lines.findIndexOf { it.startsWith("## ") }
+    if (start < 0) {
+        throw new GradleException("${changelogFile} has no '## ' version heading")
+    }
+    List<String> rest = lines.drop(start + 1)
+    int end = rest.findIndexOf { it.startsWith("## ") }
+    String body = (end < 0 ? rest : rest.take(end)).join("\n")
+    [heading: lines[start].substring(3).trim(), body: body.replaceAll(/(?s)<!--.*?-->/, "").trim()]
+}
+
+def releaseType = { String name ->
+    switch (name) {
+        case 'release': return ReleaseType.STABLE
+        case 'beta': return ReleaseType.BETA
+        case 'alpha': return ReleaseType.ALPHA
+        default: throw new GradleException("meta_release_channel must be release, beta or alpha, not '${name}'")
+    }
+}
+
+def artifact = tasks.named(project.publishArtifactTask.toString(), AbstractArchiveTask)
+
+// Proves the listing and the jar agree before anything is uploaded, and writes the resolved
+// metadata for every publication so a dry run leaves something reviewable behind. Wired into
+// `check` so the ordinary CI build exercises it on all 25 targets.
+def checkPublishMetadata = tasks.register("checkPublishMetadata") {
+    group = "publishing"
+    description = "Verifies the listing metadata against the jar's own dependency range."
+    def summaryFile = layout.buildDirectory.file("publishMods/metadata-${primaryLoader}.json")
+    inputs.property("gameVersions", gameVersions)
+    inputs.property("range", "[${mcMin},${mcMax})".toString())
+    inputs.property("channel", channel)
+    inputs.property("live", live)
+    inputs.file(changelogFile)
+    outputs.file(summaryFile)
+    doLast {
+        if (gameVersions.isEmpty()) {
+            throw new GradleException("versions/${stonecutter.current.version}/gradle.properties declares no meta_game_versions")
+        }
+        if (gameVersions.toSet().size() != gameVersions.size()) {
+            throw new GradleException("meta_game_versions repeats a version: ${gameVersions}")
+        }
+        List<String> outside = gameVersions.findAll { compareMc(it, mcMin) < 0 || compareMc(it, mcMax) >= 0 }
+        if (!outside.isEmpty()) {
+            throw new GradleException("meta_game_versions lists ${outside}, outside the jar's own range [${mcMin},${mcMax}). " +
+                "A listing must never claim a Minecraft version the jar itself refuses.")
+        }
+        if (!gameVersions.any { compareMc(it, mcVersion) == 0 }) {
+            throw new GradleException("meta_game_versions ${gameVersions} does not include the version this node is built against (${mcVersion})")
+        }
+        releaseType(channel)
+        def notes = topChangelogSection()
+        if (live && notes.heading.equalsIgnoreCase("[Unreleased]")) {
+            throw new GradleException("CHANGELOG.md still has an [Unreleased] heading; name the version before publishing live")
+        }
+        if (notes.body.isEmpty()) {
+            throw new GradleException("CHANGELOG.md's top section '${notes.heading}' is empty")
+        }
+        def summary = new groovy.json.JsonBuilder([
+            loader        : primaryLoader,
+            minecraft     : mcVersion,
+            file          : artifact.get().archiveFile.get().asFile.name,
+            versionNumber : versionNumber,
+            displayName   : displayTitle,
+            channel       : channel,
+            gameVersions  : gameVersions,
+            jarRange      : "[${mcMin},${mcMax})".toString(),
+            loaders       : loaders,
+            javaVersion   : javaRange,
+            changelogTitle: notes.heading,
+            modrinth      : modrinthProjectId,
+            curseforge    : curseforgeProjectId.isEmpty() ? null : curseforgeProjectId,
+            live          : live
+        ])
+        summaryFile.get().asFile.parentFile.mkdirs()
+        summaryFile.get().asFile.text = summary.toPrettyString()
+        logger.lifecycle("publish metadata ${primaryLoader} ${mcVersion}: ${gameVersions} ${channel}${live ? ' LIVE' : ' (dry run)'}")
+    }
+}
+
+tasks.named("check") { dependsOn checkPublishMetadata }
+tasks.named("publishMods") { dependsOn checkPublishMetadata }
+
+publishMods {
+    dryRun = !live
+    file = artifact.flatMap { it.archiveFile }
+    // One Modrinth/CurseForge version per jar, as every earlier upload did. The loader suffix keeps
+    // the Fabric and NeoForge versions of one node distinguishable on the listing.
+    version = versionNumber
+    displayName = displayTitle
+    changelog = provider { topChangelogSection().body }
+    type = releaseType(channel)
+    modLoaders.addAll(loaders)
+
+    modrinth {
+        projectId = modrinthProjectId
+        accessToken = providers.environmentVariable("MODRINTH_TOKEN")
+        minecraftVersions.addAll(gameVersions)
+        // Needed on the client; a server that also has it gains the fast packet route.
+        environment = ModrinthEnvironment.CLIENT_ONLY_SERVER_OPTIONAL
+        if (loaders.contains("fabric")) {
+            requires("fabric-api")
+        }
+    }
+
+    if (!curseforgeProjectId.isEmpty()) {
+        curseforge {
+            projectId = curseforgeProjectId
+            projectSlug = curseforgeProjectSlug
+            accessToken = providers.environmentVariable("CURSEFORGE_TOKEN")
+            minecraftVersions.addAll(gameVersions)
+            javaVersions.add(JavaVersion.toVersion(javaRange))
+            client = true
+            server = true
+            if (loaders.contains("fabric")) {
+                requires("fabric-api")
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/mightyarchitect.publish.gradle
+++ b/buildSrc/src/main/groovy/mightyarchitect.publish.gradle
@@ -15,7 +15,8 @@
 //                           published version used)
 //
 // Nothing here can upload by accident: publishMods is a dry run unless -PpublishLive=true is passed,
-// and a live run additionally refuses a CHANGELOG.md whose top section is still [Unreleased].
+// and a live run additionally refuses a CHANGELOG.md whose top heading is still marked unreleased or
+// does not name mod_version.
 import me.modmuss50.mpp.ReleaseType
 import me.modmuss50.mpp.platforms.modrinth.ModrinthEnvironment
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
@@ -112,8 +113,11 @@ def checkPublishMetadata = tasks.register("checkPublishMetadata") {
         }
         releaseType(channel)
         def notes = topChangelogSection()
-        if (live && notes.heading.equalsIgnoreCase("[Unreleased]")) {
-            throw new GradleException("CHANGELOG.md still has an [Unreleased] heading; name the version before publishing live")
+        if (live && (notes.heading.equalsIgnoreCase("[Unreleased]") || notes.heading.toLowerCase().contains("unreleased"))) {
+            throw new GradleException("CHANGELOG.md's top heading '${notes.heading}' is still marked unreleased; date it before publishing live")
+        }
+        if (live && !notes.heading.contains("[${rootProject.mod_version}]")) {
+            throw new GradleException("CHANGELOG.md's top heading '${notes.heading}' does not name mod_version ${rootProject.mod_version}")
         }
         if (notes.body.isEmpty()) {
             throw new GradleException("CHANGELOG.md's top section '${notes.heading}' is empty")

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -341,6 +341,11 @@ if (unobf) {
     }
 }
 
+// Modrinth / CurseForge publication of the jar above. See buildSrc's mightyarchitect.publish.
+ext.publishArtifactTask = unobf ? "jar" : "remapJar"
+ext.publishLoaders = ["fabric"]
+apply plugin: "mightyarchitect.publish"
+
 publishing {
     publications {
         mavenFabric(MavenPublication) {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -287,6 +287,15 @@ tasks.register("buildClientTestMod") {
     dependsOn clientTestJarTask
 }
 
+// Modrinth / CurseForge publication. The legacy plugin reobfuscates `jar` to SRG through `reobfJar`
+// and moves the official-names original to build/devlibs, so the distributable is reobfJar's output
+// (LEGACY.md: "upload the reobfJar task's output"). Listed for Forge only: 1.19.4 predates NeoForge,
+// and on 1.20.1 the production lane runs Forge 47, not NeoForge 47, so that tag would be an untested
+// claim. See buildSrc's mightyarchitect.publish.
+ext.publishArtifactTask = "reobfJar"
+ext.publishLoaders = ["forge"]
+apply plugin: "mightyarchitect.publish"
+
 publishing {
     publications {
         mavenForge(MavenPublication) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,10 @@ org.gradle.configureondemand=true
 archives_base_name=mightyarchitect
 # Shared mod version - the mod's OWN SemVer, identical across all Minecraft targets.
 # The targeted Minecraft version is carried separately as +mc<version> build metadata.
-mod_version=2.0.0-beta.1
+# 2.0.0 is the first single-branch release and supersedes every 0.x jar; it carries a server-side
+# security fix, so it ships as a full release rather than a beta. Per-node channels live in
+# versions/<node>/gradle.properties as meta_release_channel.
+mod_version=2.0.0
 maven_group=com.timmie.mightyarchitect
 
 # Toolchain plugin versions. Read by buildSrc/build.gradle, so these are the only place they live.

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,11 @@ maven_group=com.timmie.mightyarchitect
 # Fabric: official Fabric Loom. NeoForge: ModDevGradle. No third-party multiloader framework.
 loom_version=1.17.17
 moddev_version=2.0.143
+# Release publishing (Modrinth / CurseForge), applied per loader node by mightyarchitect.publish.
+mod_publish_plugin_version=2.2.0
+
+# Modrinth project this mod publishes to. CurseForge has no project yet (issue #13): leave
+# curseforge_project_id empty and the CurseForge destination is not configured at all.
+modrinth_project_id=FDYDUHRw
+curseforge_project_id=
+curseforge_project_slug=

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -236,6 +236,11 @@ jar {
     archiveClassifier.set("neoforge")
 }
 
+// Modrinth / CurseForge publication of the jar above. See buildSrc's mightyarchitect.publish.
+ext.publishArtifactTask = "jar"
+ext.publishLoaders = ["neoforge"]
+apply plugin: "mightyarchitect.publish"
+
 publishing {
     publications {
         mavenNeoForge(MavenPublication) {

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -51,3 +51,13 @@ tasks.register("unitTestAll") {
         .findAll { it != null }
         .collect { "${it.path}:test" }
 }
+
+// Publishes all 25 jars to the configured hosting platforms (see buildSrc's mightyarchitect.publish).
+// A dry run unless -PpublishLive=true is passed: each node then writes what it WOULD upload under
+// <loader>/versions/<mc>/build/publishMods/ instead of touching any platform. The release workflow
+// runs the dry run for review and the live run from a version tag.
+tasks.register("publishAll") {
+    group = "publishing"
+    description = "Publishes every version node for every loader it targets (dry run unless -PpublishLive=true)."
+    dependsOn loaderNodePaths("publishMods")
+}

--- a/versions/1.19.4/gradle.properties
+++ b/versions/1.19.4/gradle.properties
@@ -13,3 +13,9 @@ meta_mc_max=1.20
 meta_pack_format=13
 meta_forge_range=45
 meta_java_range=17
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.19.4
+meta_release_channel=beta

--- a/versions/1.19.4/gradle.properties
+++ b/versions/1.19.4/gradle.properties
@@ -16,6 +16,6 @@ meta_java_range=17
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.19.4
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.20.1/gradle.properties
+++ b/versions/1.20.1/gradle.properties
@@ -13,3 +13,9 @@ meta_mc_max=1.20.2
 meta_pack_format=15
 meta_forge_range=47
 meta_java_range=17
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.20,1.20.1
+meta_release_channel=beta

--- a/versions/1.20.1/gradle.properties
+++ b/versions/1.20.1/gradle.properties
@@ -16,6 +16,6 @@ meta_java_range=17
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.20,1.20.1
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.20.2/gradle.properties
+++ b/versions/1.20.2/gradle.properties
@@ -15,6 +15,6 @@ meta_java_range=17
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Never published before 2.0.0: beta until it has users.
 meta_game_versions=1.20.2
 meta_release_channel=beta

--- a/versions/1.20.2/gradle.properties
+++ b/versions/1.20.2/gradle.properties
@@ -12,3 +12,9 @@ meta_mc_range=1.20.2
 meta_mc_max=1.20.3
 meta_pack_format=18
 meta_java_range=17
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.20.2
+meta_release_channel=beta

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -17,6 +17,6 @@ meta_java_range=17
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Never published before 2.0.0: beta until it has users.
 meta_game_versions=1.20.3,1.20.4
 meta_release_channel=beta

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -14,3 +14,9 @@ meta_pack_format=22
 meta_neoforge_range=20.4
 meta_fml_range=2
 meta_java_range=17
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.20.3,1.20.4
+meta_release_channel=beta

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -17,6 +17,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Never published before 2.0.0: beta until it has users.
 meta_game_versions=1.20.5,1.20.6
 meta_release_channel=beta

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -14,3 +14,9 @@ meta_pack_format=32
 meta_neoforge_range=20.6
 meta_fml_range=2
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.20.5,1.20.6
+meta_release_channel=beta

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -14,3 +14,9 @@ meta_mc_max=1.21.2
 meta_pack_format=34
 meta_neoforge_range=21.1
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.21.1
+meta_release_channel=beta

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -7,8 +7,10 @@ fabric_api_version=0.110.0+1.21.1
 neoforge_version=21.1.77
 
 # Metadata dependency ranges (expanded into fabric.mod.json / neoforge.mods.toml)
+# Exact version only: 1.21.2 renamed GameRenderer.loadEffect (this jar's @Invoker target) to
+# setPostEffect, removed Registry.asLookup and every GuiGraphics.blit(ResourceLocation, ...) overload.
 meta_mc_range=1.21.1
-meta_mc_max=1.21.4
+meta_mc_max=1.21.2
 meta_pack_format=34
 meta_neoforge_range=21.1
 meta_java_range=21

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -17,6 +17,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.21.1
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -15,6 +15,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.21.10
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -12,3 +12,9 @@ meta_mc_max=1.21.11
 meta_pack_format=69
 meta_neoforge_range=21.10
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.21.10
+meta_release_channel=beta

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -15,6 +15,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.21.11
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -12,3 +12,9 @@ meta_mc_max=26.1
 meta_pack_format=75
 meta_neoforge_range=21.11
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.21.11
+meta_release_channel=beta

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -13,3 +13,9 @@ meta_mc_max=1.21.5
 meta_pack_format=46
 meta_neoforge_range=21.4
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.21.4
+meta_release_channel=beta

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -7,8 +7,9 @@ fabric_api_version=0.119.4+1.21.4
 neoforge_version=21.4.156
 
 # Metadata dependency ranges (expanded into fabric.mod.json / neoforge.mods.toml)
+# Exact version only: 1.21.5 removed RenderTarget.bindWrite, which this jar's post-chain arm calls.
 meta_mc_range=1.21.4
-meta_mc_max=1.21.6
+meta_mc_max=1.21.5
 meta_pack_format=46
 meta_neoforge_range=21.4
 meta_java_range=21

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -16,6 +16,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.21.4
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -17,6 +17,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Previously published node: full release.
 meta_game_versions=1.21.6
-meta_release_channel=beta
+meta_release_channel=release

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -7,8 +7,10 @@ fabric_api_version=0.128.2+1.21.6
 neoforge_version=21.6.20-beta
 
 # Metadata dependency ranges (expanded into fabric.mod.json / neoforge.mods.toml)
+# Exact version only: Minecraft 1.21.7 is API-identical for this mod, but NeoForge dropped
+# PacketDistributor.sendToServer (this jar's sender) partway through its 21.7 line.
 meta_mc_range=1.21.6
-meta_mc_max=1.21.8
+meta_mc_max=1.21.7
 meta_pack_format=63
 meta_neoforge_range=21.6.20-beta
 meta_java_range=21

--- a/versions/1.21.6/gradle.properties
+++ b/versions/1.21.6/gradle.properties
@@ -14,3 +14,9 @@ meta_mc_max=1.21.7
 meta_pack_format=63
 meta_neoforge_range=21.6.20-beta
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.21.6
+meta_release_channel=beta

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -17,6 +17,6 @@ meta_java_range=21
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Never published before 2.0.0: beta until it has users.
 meta_game_versions=1.21.8
 meta_release_channel=beta

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -14,3 +14,9 @@ meta_mc_max=1.21.9
 meta_pack_format=64
 meta_neoforge_range=21.8.54
 meta_java_range=21
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=1.21.8
+meta_release_channel=beta

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -7,8 +7,10 @@ fabric_api_version=0.136.1+1.21.8
 neoforge_version=21.8.54
 
 # Metadata dependency ranges (expanded into fabric.mod.json / neoforge.mods.toml)
+# Exact version only: 1.21.9 already has the input rework (MouseHandler.onButton,
+# KeyboardHandler.keyPress(long, int, KeyEvent)), so this jar's <1.21.10 mixins fail to apply there.
 meta_mc_range=1.21.8
-meta_mc_max=1.21.10
+meta_mc_max=1.21.9
 meta_pack_format=64
 meta_neoforge_range=21.8.54
 meta_java_range=21

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -16,6 +16,6 @@ meta_java_range=25
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Never published before 2.0.0: beta until it has users.
 meta_game_versions=26.1,26.1.1,26.1.2
 meta_release_channel=beta

--- a/versions/26.1/gradle.properties
+++ b/versions/26.1/gradle.properties
@@ -13,3 +13,9 @@ meta_mc_max=26.2
 meta_pack_format=84
 meta_neoforge_range=26.1.2
 meta_java_range=25
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=26.1,26.1.1,26.1.2
+meta_release_channel=beta

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -13,3 +13,9 @@ meta_mc_max=26.3
 meta_pack_format=88
 meta_neoforge_range=26.2.0
 meta_java_range=25
+
+# Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
+# declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
+# meta_release_channel: release | beta | alpha.
+meta_game_versions=26.2
+meta_release_channel=beta

--- a/versions/26.2/gradle.properties
+++ b/versions/26.2/gradle.properties
@@ -16,6 +16,6 @@ meta_java_range=25
 
 # Listing metadata (Modrinth / CurseForge). meta_game_versions is the INCLUSIVE list the listing
 # declares and must stay inside [meta_mc_range, meta_mc_max) - checkPublishMetadata enforces it.
-# meta_release_channel: release | beta | alpha.
+# meta_release_channel: release | beta | alpha. Never published before 2.0.0: beta until it has users.
 meta_game_versions=26.2
 meta_release_channel=beta


### PR DESCRIPTION
## What this is

Release-prep that fell out of the 2026-08-25 release review, in three commits so each can be judged on its own. **Nothing here settles an open release decision** — version, channel, 1.19.2 and CurseForge are all still yours — and **nothing here can upload anything** without a token in the `release` environment and a `v*` tag.

### 1. Four jars claimed Minecraft versions they were never built for — and break on every one of them

`98a9125` bounded each jar's Minecraft range at "the next version the matrix builds", which left the 1.21.1, 1.21.4, 1.21.6 and 1.21.8 jars also claiming **1.21.2/1.21.3, 1.21.5, 1.21.7 and 1.21.9**. None is in the matrix, so nothing had ever compiled against or run on them. Per the project rule — check the actual Minecraft for every version you claim — each was checked against **Mojang's published client mappings for that exact version** and, for NeoForge, the **universal jars from the NeoForged Maven**:

| jar | claimed | what the jar's *active* arms need | on the claimed version |
| --- | --- | --- | --- |
| 1.21.1 | 1.21.2, 1.21.3 | `@Invoker("loadEffect")` on `GameRenderer`; `Registry.asLookup()`; `GuiGraphics.blit(ResourceLocation, int…)` | `loadEffect` is already `setPostEffect` → **mixin apply fails at startup**; `asLookup` gone; every `blit(ResourceLocation, …)` overload gone |
| 1.21.4 | 1.21.5 | `RenderTarget.bindWrite(boolean)` in the `<1.21.6` post-chain arm | **gone** (the `GpuTexture` rework) → `NoSuchMethodError` when the blueprint effect runs |
| 1.21.6 | 1.21.7 | Minecraft side is API-identical to 1.21.6/1.21.8 ✔ — but the NeoForge `<1.21.8` sender calls `PacketDistributor.sendToServer` | NeoForge **removed it mid-21.7**: present in `21.7.0-beta`, absent in `21.7.25-beta` |
| 1.21.8 | 1.21.9 | `MouseHandler.onPress(long,int,int,int)`, `KeyboardHandler.keyPress(long,int,int,int,int)` mixin targets | 1.21.9 already has the input rework: `onButton(long, MouseButtonInfo, int)`, `keyPress(long, int, KeyEvent)` → **no injection target, hard crash at load** |

Each of the four now declares its exact version only, so a launcher refuses the jar with a dependency message instead of the game crashing. The CI metadata step reads the same properties and follows. The 1.20.4/1.20.6 nodes still fold 1.20.3/1.20.5 in deliberately — hotfix stubs bundled with their *successor*, the opposite shape.

### 2. `CHANGELOG.md`

Everything merged since the last published jars (#31 → #44), written for players: security first (servers that ran any earlier jar should update and check `/gamerule logAdminCommands`), fixes by symptom, and the two items that only ever broke inside the unreleased window (reflective post-effect lookup, legacy-Forge refmap) under *Internal*. Two placeholders are marked in an HTML comment: the `[Unreleased]` heading and the 1.19.x *Removed* entry.

### 3. Release publishing, behind an explicit and verified dry run

There was no way to publish the 25 jars at all. Now:

- **`buildSrc/…/mightyarchitect.publish.gradle`** (mod-publish-plugin 2.2.0, one shared classloader like the other convention plugins), applied by all three branch scripts. Distributable per loader: `remapJar`/`jar` on Fabric, `jar` on NeoForge, **`reobfJar` on legacy Forge** (LEGACY.md: "upload the reobfJar task's output" — verified the dry-run jar is the SRG one: 49 `m_*_` call sites, no official names). One Modrinth version per jar with the loader-suffixed number every earlier upload used (`2.0.0-beta.1+mc1.21.1-fabric`); Fabric API declared `required` on Fabric; Modrinth environment `client_only_server_optional`, which is what #43 made true.
- **Game versions are explicit per node** (`meta_game_versions`), never derived from the exclusive `meta_mc_max`. A new **`checkPublishMetadata`** task — part of `check`, so part of every CI build on all 25 targets — fails if a listed version falls outside the jar's own `[meta_mc_range, meta_mc_max)`, if the node's own version is missing, or if the channel is invalid. **Mutation-tested**: listing 1.20.2 on the 1.20.1 node fails with the range named. Listing = the jar's range written inclusively: exact everywhere except the deliberate bundles (1.20.1 + 1.20; 1.20.4 + 1.20.3; 1.20.6 + 1.20.5; 26.1 built against 26.1.2 + the 26.1/26.1.1 hotfix stubs — the one judgment call, same shape as the 1.20 stubs).
- **Channel per node** (`meta_release_channel`, default `beta` = the channel of all 30 previous uploads). The recommendation — `release` on the 7 previously published nodes, `beta` on the 6 new — is a one-line edit per node when you decide.
- **CurseForge** is configured only when `curseforge_project_id` is set (#13); until then only Modrinth exists.
- **`publishMods` is a dry run unless `-PpublishLive=true`**: it writes the jar + resolved metadata under `build/publishMods/` and touches no platform. A live run additionally refuses a `CHANGELOG.md` still headed `[Unreleased]`. Release notes = that file's top section. `./gradlew publishAll` does all 25.
- **`release.yml`**: runs the full build matrix on the commit (reusable-workflow call), then a 13-job dry run whose resolved metadata is tabulated in the run summary and uploaded as artifacts; `workflow_dispatch` stops there — that *is* the "review the dry run for all 25" gate. A `v<mod_version>` tag continues to the live upload from the **`release` environment**: put `MODRINTH_TOKEN` there (not as a repository secret PR builds can see) and add yourself as a required reviewer to make the upload a manual approval with the dry-run artifacts in hand. A tag that does not match `mod_version` fails before anything runs.
- `build.yml` no longer triggers on tags (the release workflow builds the matrix once) but still runs on every branch push, so throwaway-branch mutation testing keeps working.

## Validation

- `processResources` on 1.21.1/1.21.6 → `>=1.21.1 <1.21.2`, `[1.21.6,1.21.7)`; Mojang mappings for 1.21.1…1.21.10 and NeoForge `21.6.20`/`21.7.0`/`21.7.25` probed as above.
- `checkPublishMetadata` on Fabric 1.21.1, 26.1 (unobf `jar` path), NeoForge 1.21.1, 1.20.4, Forge 1.20.1; `publishMods` dry run on Forge 1.20.1 and Fabric 1.20.2; mutation of the range check red then green; `:fabric:1.21.1:build --dry-run` shows `checkPublishMetadata` in the ordinary graph.
- Both workflow files parse; CI on this branch exercises `checkPublishMetadata` on all 25 targets via `check`.
- A `workflow_dispatch` dry run of `release.yml` on this branch is linked in the comments below.

## Decisions applied in the last commit (each is a one-line revert if you disagree)

- **`mod_version=2.0.0`**, channel **`release` on the seven previously published nodes** (1.19.4, 1.20.1, 1.21.1, 1.21.4, 1.21.6, 1.21.10, 1.21.11) and **`beta` on the six never-published ones** (1.20.2, 1.20.4, 1.20.6, 1.21.8, 26.1, 26.2). Rationale: all 30 prior uploads were betas, and a beta-only security fix is a delivery brake for the users who need it; the new nodes stay beta until they have users.
- `CHANGELOG.md` is headed `[2.0.0] — unreleased`. **A live publish is refused while the heading says unreleased or does not name `mod_version`**, so dating it is the last deliberate act before a tag can upload anything.
- README intro: names all three loaders and the version span, points at Modrinth and the changelog, drops "WIP / experimental".

## What you still have to do before tagging

1. **1.19.2 / 1.19.3** — the one decision left in the file: keep the *Removed* entry (EOL; 634/94 downloads a year; 0.6.2 carries the packet-authorization hole) or add a 1.19.2 node.
2. Create the **`release` environment** with `MODRINTH_TOKEN` (scopes: create/read/write versions) and, ideally, yourself as required reviewer. `CURSEFORGE_TOKEN` + `curseforge_project_id` only once a CF project exists.
3. After merge: `workflow_dispatch` the Release workflow on `main` and read the 25-row table.
4. Date the changelog heading, push `v2.0.0`, approve the environment.