### PR TITLE
Make releases require one environment approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,9 @@ jobs:
     environment: release
     strategy:
       fail-fast: false
-      max-parallel: 3
+      # All matrix jobs must reach the protected environment together so one review approves every
+      # deployment. Limiting parallelism here batches the deployments and asks for another review
+      # after each batch; GitHub still schedules the approved jobs against the available runner pool.
       matrix:
         include:
           - { mc: "1.19.4",  loader2: forge }


### PR DESCRIPTION
## Why

The v2.0.0 release needed five environment reviews because `max-parallel: 3` allowed only three matrix jobs to reach the protected `release` environment at once. Each later batch created new deployments and therefore required another review.

## Fix

Remove the publish matrix concurrency cap. All 13 per-version jobs now reach the protected environment together, so GitHub presents them in one review. After approval, runner availability still limits actual execution; the per-version job shape and safe "rerun failed jobs only" recovery are unchanged.

No publishing metadata or upload behavior changes.